### PR TITLE
Continuing instead of returning failure when template cannot map to o…

### DIFF
--- a/src/NFcore/templateMolecule.cpp
+++ b/src/NFcore/templateMolecule.cpp
@@ -1296,7 +1296,8 @@ bool TemplateMolecule::compare(Molecule *m, ReactantContainer *rc, MappingSet *m
 						if(!match) { continue; } //keep going if we can't match
 					} else {
 						//cout<<"could not map other side!"<<endl;
-						clear(); return false;
+						//clear(); return false;
+						continue;
 					}
 				} else { //Phew!  we can check this guy normally.
 


### PR DESCRIPTION
…ne of the symmetric components

The compare method inside of templatemolecule was returning failure when a symmetric component could not map to the template
described in the class. This was resulting in the compare method not testing for other possible mappings in subsequent symmetric components,
which was resulting in missed mappings in complexes of the form L(s...,s!1).R(s!1,s...)

The solution was to change the return false for a continue, similar to how the method kept checking when it couldn't find an exact template match for a component
that it could otherwise map.

This commit partially addresses the bug reported in issue#3