### PR TITLE
Remove reaction tagging for output and add new options to help

### DIFF
--- a/src/NFinput/NFinput.cpp
+++ b/src/NFinput/NFinput.cpp
@@ -1828,20 +1828,20 @@ bool NFinput::initReactionRules(
 					}
 				}
 
-				if( !pRateLaw->Attribute("tag") ) {
-					cerr<<"\n!!Error! This XML file was generated using an older version of BioNetGen that does not support the 'TotalRate' convention!"<<endl;
-					cerr<<"You should upgrade your BioNetGen distribution now, or download the latest NFsim package, and regenerate this XML file."<<endl;
-				} else {
-					try {
-						int rf = NFutil::convertToInt(pRateLaw->Attribute("tag"));
-						if(rf>0) tagFlag=true;
-						if(verbose) cout<<"\t\t\t= "<<tagFlag<<endl;
-					} catch (std::runtime_error &e1) {
-						//cerr<<e1.what()<<endl;
-						cerr<<"Error!! tag flag for ReactionRule "<<rxnName<<" was not set properly.  quitting."<<endl;
-						exit(1);
-					}
-				}
+				// if( !pRateLaw->Attribute("tag") ) {
+				// 	cerr<<"\n!!Error! This XML file was generated using an older version of BioNetGen that does not support the 'TotalRate' convention!"<<endl;
+				// 	cerr<<"You should upgrade your BioNetGen distribution now, or download the latest NFsim package, and regenerate this XML file."<<endl;
+				// } else {
+				// 	try {
+				// 		int rf = NFutil::convertToInt(pRateLaw->Attribute("tag"));
+				// 		if(rf>0) tagFlag=true;
+				// 		if(verbose) cout<<"\t\t\t= "<<tagFlag<<endl;
+				// 	} catch (std::runtime_error &e1) {
+				// 		//cerr<<e1.what()<<endl;
+				// 		cerr<<"Error!! tag flag for ReactionRule "<<rxnName<<" was not set properly.  quitting."<<endl;
+				// 		exit(1);
+				// 	}
+				// }
 
 				if(!pRateLaw->Attribute("id") || !pRateLaw->Attribute("type")) {
 					cerr<<"!!Error:: ReactionRule "<<rxnName<<" rate law specification: cannot read 'id' or 'type' attribute!"<<endl;
@@ -2264,10 +2264,10 @@ bool NFinput::initReactionRules(
 					// Add the reactant and product templates to the reaction class
 					r->setAllReactantAndProductTemplates(reactants, products);
 					r->setTotalRateFlag(totalRateFlag);
-					if (tagFlag) {
+					// if (tagFlag) {
 						r->tag();
 						s->turnOnTagRxnOutput();
-					}
+					// }
 					// Use reaction connectivity flag
 					// Set to true if given on the command line
 					r->setConnectivityFlag(s->getConnectivityFlag());

--- a/src/NFsim.cpp
+++ b/src/NFsim.cpp
@@ -79,7 +79,7 @@
  *  -connect - infer network connectivity before starting simulation. (default: no).
  *             @author Arvind Rasi Subramaniam
  * 
- *  -rxnlog - write out firing time and molecules for all reactions
+ *  -rxnlog [filename] - write out firing time and participating molecules for all reactions to file
  *             Does not require any modification to BioNetGen or PySB.
  *             @author Arvind Rasi Subramaniam
  *
@@ -742,13 +742,13 @@ void printHelp(string version)
 	cout<<""<<endl;
     cout<<"  -connect          infer network connectivity before starting simulation. (default: no)."<<endl;
 	cout<<""<<endl;
- 	cout<<"  -rxnlog           write out firing time and participating molecules for all reactions."<<endl;
+ 	cout<<"  -rxnlog [filename] write out firing time and participating molecules for all reactions."<<endl;
 	cout<<""<<endl;
  	cout<<"  -trackconnected   write out the reactions whose rates change after firing of each reaction."<<endl;
-	cout<<"                    this works only if -rxnlog switch is included."<<endl;
+	cout<<"                    this works only if -rxnlog switch is included. Useful for debugging models."<<endl;
 	cout<<""<<endl;
  	cout<<"  -printconnected   print connectivity of each reaction to an output file."<<endl;
-	cout<<"                    this works only if -rxnlog switch is included."<<endl;
+	cout<<"                    this works only if -rxnlog switch is included. Useful for debugging models."<<endl;
 	cout<<""<<endl;
  	cout<<"  -trackrxnnum      track reaction number instead of name. this helps to keep the rxn log file small."<<endl;
 	cout<<"                    this works only if -rxnlog switch is included."<<endl;

--- a/src/NFsim.cpp
+++ b/src/NFsim.cpp
@@ -75,20 +75,24 @@
  *  -notf = disables On the Fly Observables, see manual
  *
  *  -cb = turn on complex bookkeeping, see manual
- *
+ * 
  *  -connect - infer network connectivity before starting simulation. (default: no).
+ *             @author Arvind Rasi Subramaniam
+ * 
+ *  -rxnlog - write out firing time and molecules for all reactions
  *             Does not require any modification to BioNetGen or PySB.
  *             @author Arvind Rasi Subramaniam
  *
- *  -printconnected - print connectivity of each reaction to an output file. (default: no).
- *             @author Arvind Rasi Subramaniam
- *
  *  -trackconnected - write out the reactions whose rates change after firing of each reaction.
- *  				  Default: false
+ * 					  this works only if -rxnlog switch is included
  *  				  @author: Arvind Rasi Subramaniam
+ * 
+ *  -printconnected - print connectivity of each reaction to an output file. (default: no).
+ * 					  this works only if -rxnlog switch is included
+ 		*             @author Arvind Rasi Subramaniam
  *
  *  -trackrxnnum - track reaction number instead of name. this helps to keep the rxn log file small.
- *  			   Default: false
+ *	    		   this works only if -rxnlog switch is included
  *  			   @author: Arvind Rasi Subramaniam
  *
 *   -maxcputime - maximum run time for simulation in seconds (default: 1000s).
@@ -516,37 +520,32 @@ System *initSystemFromFlags(map<string,string> argMap, bool verbose)
 					}
 				}
 
-				if (s->getAnyRxnTagged()) {
-					if (argMap.find("rxnlog") != argMap.end()) {
-						string rxnLogFileName = argMap.find("rxnlog")->second;
-						s->registerReactionFileLocation(rxnLogFileName);
-						// track the reactions whose rates change upon each each reaction
-						// firing. This is useful for debugging to make sure that all the
-						// right reactions are updated after each firing.
-						// Arvind Rasi Subramaniam Nov 21, 2018
-						if (argMap.find("trackconnected") != argMap.end()) {
-							s->registerConnectedRxnFileLocation(
-									rxnLogFileName.replace(
-											rxnLogFileName.end()-4,
-											rxnLogFileName.end(),
-											"_connected.tsv"));
-							s->setTrackConnected(true);
-						} else {
-							s->setTrackConnected(false);
-						}
-						if (argMap.find("printconnected") != argMap.end()) {
-							s->registerListOfConnectedRxnFileLocation(
-									rxnLogFileName.replace(
-											rxnLogFileName.end()-4,
-											rxnLogFileName.end(),
-											"_connectedlist.tsv"));
-							s->setPrintConnected(true);
-						} else {
-							s->setPrintConnected(false);
-						}
+				if (argMap.find("rxnlog") != argMap.end()) {
+					string rxnLogFileName = argMap.find("rxnlog")->second;
+					s->registerReactionFileLocation(rxnLogFileName);
+					// track the reactions whose rates change upon each each reaction
+					// firing. This is useful for debugging to make sure that all the
+					// right reactions are updated after each firing.
+					// Arvind Rasi Subramaniam Nov 21, 2018
+					if (argMap.find("trackconnected") != argMap.end()) {
+						s->registerConnectedRxnFileLocation(
+								rxnLogFileName.replace(
+										rxnLogFileName.end()-4,
+										rxnLogFileName.end(),
+										"_connected.tsv"));
+						s->setTrackConnected(true);
 					} else {
-						s->registerReactionFileLocation(
-								s->getName() + "_rxns.dat");
+						s->setTrackConnected(false);
+					}
+					if (argMap.find("printconnected") != argMap.end()) {
+						s->registerListOfConnectedRxnFileLocation(
+								rxnLogFileName.replace(
+										rxnLogFileName.end()-4,
+										rxnLogFileName.end(),
+										"_connectedlist.tsv"));
+						s->setPrintConnected(true);
+					} else {
+						s->setPrintConnected(false);
 					}
 					if (argMap.find("trackrxnnum") != argMap.end()) {
 						s->setRxnNumberTrack(true);
@@ -554,6 +553,7 @@ System *initSystemFromFlags(map<string,string> argMap, bool verbose)
 						s->setRxnNumberTrack(false);
 					}
 				}
+				// }
 
 
 				//turn off on the fly calculation of observables
@@ -739,6 +739,21 @@ void printHelp(string version)
 	cout<<"                    exact same results perhaps to compare performance"<<endl;
 	cout<<""<<endl;
 	cout<<"  -logo             prints out the ascii NFsim logo, for your viewing pleasure."<<endl;
+	cout<<""<<endl;
+    cout<<"  -connect          infer network connectivity before starting simulation. (default: no)."<<endl;
+	cout<<""<<endl;
+ 	cout<<"  -rxnlog           write out firing time and participating molecules for all reactions."<<endl;
+	cout<<""<<endl;
+ 	cout<<"  -trackconnected   write out the reactions whose rates change after firing of each reaction."<<endl;
+	cout<<"                    this works only if -rxnlog switch is included."<<endl;
+	cout<<""<<endl;
+ 	cout<<"  -printconnected   print connectivity of each reaction to an output file."<<endl;
+	cout<<"                    this works only if -rxnlog switch is included."<<endl;
+	cout<<""<<endl;
+ 	cout<<"  -trackrxnnum      track reaction number instead of name. this helps to keep the rxn log file small."<<endl;
+	cout<<"                    this works only if -rxnlog switch is included."<<endl;
+	cout<<""<<endl;
+ 	cout<<"  -maxcputime       maximum run time for simulation in seconds (default: 1000s)."<<endl;
 	cout<<""<<endl;
 	cout<<""<<endl;
 }


### PR DESCRIPTION
- I removed the tagging of reactions since this relied on a customized version of PySB and BioNetGen that is unnecessary. Instead, all reactions are output to a file when the `-rxnlog` switch is given along with a filename. 
- I added the new options to the help message printed when `NFsim -help` is run.