### PR TITLE
feat: add optional library build target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,16 @@ project(NFsim)
 
 set(CMAKE_BUILD_TYPE Release)
 
+# Optional targets for embedding NFsim as a library or building the CLI.
+option(NFSIM_BUILD_EXECUTABLE "Build the NFsim command line executable" ON)
+option(NFSIM_BUILD_LIBRARY "Build NFsim as a reusable library target" OFF)
+
 # Option to use ExprTk instead of muParser for expression parsing
 option(NFSIM_USE_EXPRTK "Use ExprTk instead of muParser (requires C++17)" OFF)
+
+if(NOT NFSIM_BUILD_EXECUTABLE AND NOT NFSIM_BUILD_LIBRARY)
+    message(FATAL_ERROR "Enable at least one of NFSIM_BUILD_EXECUTABLE or NFSIM_BUILD_LIBRARY.")
+endif()
 
 set(SUB_DIRS
     src/nauty24
@@ -71,21 +79,56 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/NFtest/util/util_test.cpp")
     list(FILTER src_files EXCLUDE REGEX "[/\\\\]src[/\\\\]NFtest[/\\\\]util[/\\\\]util_test\\.cpp$")
 endif()
 
+# The CLI entrypoint is built separately so the shared implementation can also
+# be packaged as a library.
+list(FILTER src_files EXCLUDE REGEX "[/\\\\]src[/\\\\]NFsim_main\\.cpp$")
+
 set(SRC_FILES
     ${src_files}
     ${c_src_files}
 )
 
-add_executable(${PROJECT_NAME} ${SRC_FILES})
+set(NFSIM_OBJECT_TARGET "${PROJECT_NAME}_objects")
+add_library(${NFSIM_OBJECT_TARGET} OBJECT ${SRC_FILES})
+
+if(NFSIM_BUILD_LIBRARY)
+    set_target_properties(${NFSIM_OBJECT_TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
 
 # Set C++ standard based on parser choice
 if(NFSIM_USE_EXPRTK)
-    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE NFSIM_USE_EXPRTK)
+    set(NFSIM_CXX_STANDARD_FEATURE cxx_std_17)
+    target_compile_definitions(${NFSIM_OBJECT_TARGET} PRIVATE NFSIM_USE_EXPRTK)
 else()
-    target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+    set(NFSIM_CXX_STANDARD_FEATURE cxx_std_11)
 endif()
 
+target_compile_features(${NFSIM_OBJECT_TARGET} PRIVATE ${NFSIM_CXX_STANDARD_FEATURE})
+
 if(NOT MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated-declarations)
+    target_compile_options(${NFSIM_OBJECT_TARGET} PRIVATE -Wno-deprecated-declarations)
+endif()
+
+if(NFSIM_BUILD_LIBRARY)
+    add_library(nfsim $<TARGET_OBJECTS:${NFSIM_OBJECT_TARGET}>)
+    target_include_directories(nfsim PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
+    target_compile_features(nfsim PUBLIC ${NFSIM_CXX_STANDARD_FEATURE})
+
+    if(NFSIM_USE_EXPRTK)
+        target_include_directories(nfsim PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src/NFfunction/exprtk")
+        target_compile_definitions(nfsim PUBLIC NFSIM_USE_EXPRTK)
+    endif()
+endif()
+
+if(NFSIM_BUILD_EXECUTABLE)
+    add_executable(${PROJECT_NAME} src/NFsim_main.cpp $<TARGET_OBJECTS:${NFSIM_OBJECT_TARGET}>)
+    target_compile_features(${PROJECT_NAME} PRIVATE ${NFSIM_CXX_STANDARD_FEATURE})
+
+    if(NFSIM_USE_EXPRTK)
+        target_compile_definitions(${PROJECT_NAME} PRIVATE NFSIM_USE_EXPRTK)
+    endif()
+
+    if(NOT MSVC)
+        target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated-declarations)
+    endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ maintained alternative. To enable ExprTk:
 - Faster expression evaluation
 - Future-proof against compiler evolution
 
+### Optional: Build NFsim as a Library
+
+By default, NFsim builds only the `NFsim` command-line executable. You can also
+build a reusable `nfsim` library target from the same source tree:
+
+    mkdir build
+    cd build
+    cmake -DNFSIM_BUILD_LIBRARY=ON ..
+    make
+
+To build only the library and skip the CLI executable:
+
+    cmake -DNFSIM_BUILD_LIBRARY=ON -DNFSIM_BUILD_EXECUTABLE=OFF ..
+
+To request a shared library instead of the default static library, also set:
+
+    cmake -DNFSIM_BUILD_LIBRARY=ON -DBUILD_SHARED_LIBS=ON ..
+
+The `NFSIM_USE_EXPRTK` option works with either the executable or library
+targets.
+
 If you've built it with Cygwin and you want to move or package up the
 executable, you'll need to copy the the following DLLs along with it:
 

--- a/src/NFsim.cpp
+++ b/src/NFsim.cpp
@@ -211,7 +211,7 @@ System *initSystemFromFlags(map<string,string> argMap, bool verbose);
 /*!
   @author Michael Sneddon
 */
-int main(int argc, char *argv[])
+int runNFsimMain(int argc, char *argv[])
 {
 
 
@@ -957,7 +957,6 @@ void printHelp(string version)
 	cout<<""<<endl;
 	cout<<""<<endl;
 }
-
 
 
 

--- a/src/NFsim.hh
+++ b/src/NFsim.hh
@@ -44,6 +44,13 @@
 
 
 
+//! Runs the NFsim command-line entrypoint using argv-style arguments.
+/*!
+  @author Michael Sneddon
+*/
+int runNFsimMain(int argc, char *argv[]);
+
+
 //! Runs a given System with the specified arguments
 /*!
   @author Michael Sneddon

--- a/src/NFsim_main.cpp
+++ b/src/NFsim_main.cpp
@@ -1,0 +1,6 @@
+#include "NFsim.hh"
+
+int main(int argc, char *argv[])
+{
+	return runNFsimMain(argc, argv);
+}


### PR DESCRIPTION
## Summary
- split the CLI main into a tiny wrapper and a reusable `runNFsimMain()` entrypoint
- add CMake options to build the `NFsim` executable, a reusable `nfsim` library target, or both from the same shared object set
- preserve current parser behavior: muParser remains the default for whichever targets are enabled, and `NFSIM_USE_EXPRTK=ON` switches the enabled target(s) to ExprTk
- document library-only, shared-library, and parser-selection build combinations in the README

## Scope
- This PR is about target selection for embedding and packaging.
- It does not change NFsim's default parser.
- It does not attempt to build mixed parser variants in one CMake configure, such as an executable with muParser and a library with ExprTk at the same time.

## Validation
- `cmake -S . -B /tmp/nfsim-build-default`
- `cmake --build /tmp/nfsim-build-default -j4`
- `cmake -S . -B /tmp/nfsim-build-libonly -DNFSIM_BUILD_LIBRARY=ON -DNFSIM_BUILD_EXECUTABLE=OFF`
- `cmake --build /tmp/nfsim-build-libonly -j4`
- `cmake -S . -B /tmp/nfsim-build-shared-exprtk -DNFSIM_BUILD_LIBRARY=ON -DNFSIM_BUILD_EXECUTABLE=OFF -DBUILD_SHARED_LIBS=ON -DNFSIM_USE_EXPRTK=ON`
- `cmake --build /tmp/nfsim-build-shared-exprtk -j4`