### PR TITLE
Fix use-after-free in resetConcentrations() / SystemSnapshot::restore()

### DIFF
--- a/src/NFcore/moleculeType.cpp
+++ b/src/NFcore/moleculeType.cpp
@@ -394,12 +394,19 @@ void MoleculeType::removeMoleculeFromRunningSystem(Molecule *&m)
 
 void MoleculeType::removeAllMolecules()
 {
-	// Iterate through all molecules and remove them
-	// We need to loop backwards because remove() removes by swapping with the last element
+	// Iterate through all molecules and remove them. Loop backwards because
+	// remove() removes by swapping with the last element.
+	//
+	// Do NOT delete the Molecule objects here: mList is a fixed-capacity pool
+	// that owns every Molecule across [0, capacity) and recycles them on
+	// genDefaultMolecule()/create(). remove() only unbinds, drops the molecule
+	// from observables/reactions, marks it dead, and decrements the live count
+	// — the object stays in the pool for reuse. Deleting it leaves a dangling
+	// pointer in the pool (use-after-free on the next create()) and a double
+	// free in ~MoleculeList(). This is the crash behind resetConcentrations().
 	for (int m = mList->size() - 1; m >= 0; m--) {
 		Molecule *mol = mList->at(m);
 		removeMoleculeFromRunningSystem(mol);
-		delete mol; // Free the memory to prevent leaks
 	}
 }
 

--- a/src/NFcore/system.cpp
+++ b/src/NFcore/system.cpp
@@ -1438,13 +1438,22 @@ void System::updateAllReactionPropensities() {
 
 void System::destroyAllMolecules() {
 	invalidateStepToCache();
-	// For each MoleculeType, remove all molecules
+	// For each MoleculeType, remove all molecules. removeAllMolecules() unbinds
+	// every molecule and decrements the per-type live count to zero, but leaves
+	// the Molecule objects in their MoleculeList pools for reuse (see the note
+	// there). Unbinding routes through Complex::updateComplexMembership(), which
+	// splits each former complex back into singletons, so the pooled molecules
+	// stay paired with valid, in-range complex IDs.
 	for (auto molTypeIter = allMoleculeTypes.begin(); molTypeIter != allMoleculeTypes.end(); ++molTypeIter) {
 		(*molTypeIter)->removeAllMolecules();
 	}
 
-	// Clear all complexes from the list
-	allComplexes.clearAllComplexes();
+	// Deliberately do NOT clearAllComplexes() here. The Complex objects are
+	// referenced by the recycled pool molecules via ID_complex; deleting them
+	// would leave those molecules pointing at freed/out-of-range complexes the
+	// next time genDefaultMolecule() hands them back during restore. The complex
+	// list and its available-complex queue stay internally consistent across the
+	// destroy/recreate cycle on their own.
 
 	// Reset all observable counts
 	for (auto obsIter = obsToOutput.begin(); obsIter != obsToOutput.end(); ++obsIter) {


### PR DESCRIPTION
## Problem

`resetConcentrations()` (and any other path through
`System::destroyAllMolecules()`, e.g. the `.rnf` `reset_system` command)
crashes the process — typically a SIGSEGV inside `SystemSnapshot::restore()`,
or a double free at teardown. It reproduces on any model: save state, then
reset, with no mutation in between.

## Root cause

`MoleculeList` is a fixed-capacity **object pool**:

- `create()` hands back a pre-allocated `Molecule` from its internal array and
  bumps a counter — it does not allocate per molecule.
- `remove()` only unbinds and swaps-and-decrements the live count.
- `~MoleculeList()` owns and `delete`s every slot in `[0, capacity)`.

`MoleculeType::removeAllMolecules()` additionally called `delete mol` on each
pooled molecule. That leaves a dangling pointer in the pool, so the next
`genDefaultMolecule()`/`create()` returns freed memory (use-after-free), and
`~MoleculeList()` later frees it again (double free).

In parallel, `destroyAllMolecules()` called `clearAllComplexes()`, deleting the
`Complex` objects that the recycled pool molecules still reference by
`ID_complex` — stranding them on the next restore.

## Fix

- `removeAllMolecules()` tears each molecule down (unbind, drop from
  observables/reactions, mark dead, decrement) **without** deleting it, leaving
  the object in the pool for reuse.
- `destroyAllMolecules()` no longer deletes the complex list. Unbinding already
  routes through `Complex::updateComplexMembership()`, which splits each former
  complex back into singletons, so the pooled molecules stay paired with valid,
  in-range complex IDs and the available-complex queue stays consistent across
  the destroy/recreate cycle.

Two files, +22/-6, comments only besides the two removed lines.

## Verification

`save_concentrations` → mutate → `reset_concentrations` → simulate round-trips
correctly on models with bonded complexes (verified both with and without
complex bookkeeping / `-cb`), the restored observable counts match the saved
state exactly, and the `System` tears down without a double free.