### PR TITLE
Fix reactant-selector teardown double-free in TransformationSet

### DIFF
--- a/src/NFreactions/transformations/transformationSet.cpp
+++ b/src/NFreactions/transformations/transformationSet.cpp
@@ -99,13 +99,15 @@ TransformationSet::~TransformationSet()
 		delete t;
 	}
 
-	for (auto &rf : reactantFilters) {
-		// Clean up all templates generated for this filter pattern
-		for (auto &kv : rf.parsedTemplates) {
-			delete kv.second;
-		}
-		// Note: we don't delete rf.pattern directly since it is one of the parsedTemplates and handled above
-	}
+	// Do NOT delete rf.parsedTemplates here. Every TemplateMolecule produced by
+	// readPattern() for a reactant selector is registered with its MoleculeType
+	// and freed when System deletes all MoleculeTypes (see system.cpp,
+	// "Delete all MoleculeTypes (which deletes all molecules and templates)").
+	// Deleting them here is a second free of the same objects, which double-frees
+	// across the System teardown — intermittently on a single selector session,
+	// deterministically once two selector-bearing sessions share a process
+	// (SIGABRT/SIGSEGV). rf.pattern is one of these templates, so it must not be
+	// deleted here either.
 	reactantFilters.clear();
 
 	delete [] transformations;


### PR DESCRIPTION
`TransformationSet::~TransformationSet()` deletes every `TemplateMolecule` held in each `ReactantFilter`'s `parsedTemplates` map. Those templates are produced by `NFinput::readPattern()` while parsing `include_reactants()` / `exclude_reactants()` (added in #23) and are registered with their `MoleculeType`, which already frees them when `System` deletes all `MoleculeType`s on teardown. Deleting them again in the destructor is a **second free of the same objects**.

### Symptom
- Intermittent crash when a single selector-bearing model is torn down.
- Deterministic once two selector-bearing simulations run in one process (SIGABRT from the allocator, or SIGSEGV).

Library/embedding consumers that create many NFsim sessions per process (e.g. parameter fitting) crash on any model using reactant selectors.

### Root cause
`MoleculeType` is the sole owner of these `TemplateMolecule`s and frees them on `System` teardown (`system.cpp`, "Delete all MoleculeTypes (which deletes all molecules and templates)"). The `parsedTemplates` map in `ReactantFilter` holds the same pointers, so the destructor's `delete kv.second` loop double-frees them. `rf.pattern` is one of those same templates.

### Fix
Stop deleting `parsedTemplates` (and `rf.pattern`) in `~TransformationSet()`; leave ownership with `MoleculeType`. Selector enforcement behavior from #23 is unchanged — only the redundant free is removed.

### Validation
Reproduced deterministically with two selector-bearing sessions in one process (12/12 crashes), 0/20 after the fix. Applies cleanly on current `master`.

Related: #63 (selectors silently ignored), #23 (selector enforcement that introduced the teardown path).