### PR TITLE
Fix loss of precision in MM rate law when Km is small and the enzyme is in excess

### DIFF
--- a/src/NFreactions/reactions/reaction.cpp
+++ b/src/NFreactions/reactions/reaction.cpp
@@ -187,7 +187,15 @@ double MMRxnClass::update_a()
 {
 	double S = (double)getCorrectedReactantCount(0);
 	double E = (double)getCorrectedReactantCount(1);
-	sFree=0.5*( (S-Km-E) + pow((pow( (S-Km-E),2.0) + 4.0*Km*S),  0.5) );
+	// Free substrate is the non-negative root of sFree^2 - b*sFree - Km*S = 0, b = S-Km-E.
+	// The textbook form 0.5*(b + sqrt(b*b + 4*Km*S)) cancels catastrophically when b < 0,
+	// and rounds to exactly zero once 4*Km*S drops below about 1e-16*b*b, which silently
+	// stops the reaction when Km is small and the enzyme is in excess. The two roots
+	// multiply to -Km*S, so the b < 0 case is written as a sum of like-signed quantities.
+	// See https://github.com/RuleWorld/bionetgen/issues/323
+	double b = S-Km-E;
+	double q = sqrt(b*b + 4.0*Km*S);
+	sFree = (b>=0.0) ? 0.5*(b+q) : 2.0*Km*S/(q-b);
 	a=kcat*sFree*E/(Km+sFree);
 	return a;
 }

--- a/test/MM/mm_small_km.bngl
+++ b/test/MM/mm_small_km.bngl
@@ -1,0 +1,34 @@
+# Regression fixture for the Michaelis-Menten rate law with a small Km and the
+# enzyme in excess. See https://github.com/RuleWorld/bionetgen/issues/323.
+#
+# With Km << E - S the free substrate is Km*S/(E-S) and the propensity reduces to
+# kcat*S, so the substrate decays as a first order death process and the product
+# follows P(t) = S0*(1 - exp(-kcat*t)). The free substrate used to be computed as
+# 0.5*(b + sqrt(b*b + 4*Km*S)) with b = S - Km - E, which rounds to exactly zero
+# for these parameters, leaving a propensity of zero and a reaction that never fires.
+begin model
+begin parameters
+  kcat 1.0
+  Km   1e-15
+end parameters
+begin molecule types
+  S()
+  E()
+  P()
+end molecule types
+begin seed species
+  S()  100
+  E()  200
+  P()    0
+end seed species
+begin observables
+  Molecules Pn P()
+  Molecules Sn S()
+end observables
+begin reaction rules
+  R: S() + E() -> P() + E()  MM(kcat,Km)
+end reaction rules
+end model
+begin actions
+writeXML()
+end actions

--- a/test/MM/mm_small_km.xml
+++ b/test/MM/mm_small_km.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by BioNetGen 2.9.3  -->
+<sbml xmlns="http://www.sbml.org/sbml/level3" level="3" version="1">
+  <model id="mm_small_km">
+    <ListOfParameters>
+      <Parameter id="kcat" type="Constant" value="1" expr="1.0"/>
+      <Parameter id="Km" type="Constant" value="1e-15" expr="1e-15"/>
+    </ListOfParameters>
+    <ListOfMoleculeTypes>
+      <MoleculeType id="E"/>
+      <MoleculeType id="P"/>
+      <MoleculeType id="S"/>
+    </ListOfMoleculeTypes>
+    <ListOfCompartments>
+    </ListOfCompartments>
+    <ListOfSpecies>
+      <Species id="S1"  concentration="100" name="S()">
+        <ListOfMolecules>
+          <Molecule id="S1_M1" name="S"/>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S2"  concentration="200" name="E()">
+        <ListOfMolecules>
+          <Molecule id="S2_M1" name="E"/>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S3"  concentration="0" name="P()">
+        <ListOfMolecules>
+          <Molecule id="S3_M1" name="P"/>
+        </ListOfMolecules>
+      </Species>
+    </ListOfSpecies>
+    <ListOfReactionRules>
+      <ReactionRule id="RR1" name="R" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR1_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_RP1_M1" name="S"/>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR1_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR1_RP2_M1" name="E"/>
+            </ListOfMolecules>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR1_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_PP1_M1" name="P"/>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR1_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR1_PP2_M1" name="E"/>
+            </ListOfMolecules>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR1_RateLaw" type="MM" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+            <RateConstant value="Km"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR1_RP1_M1"/>
+          <MapItem sourceID="RR1_RP2_M1" targetID="RR1_PP2_M1"/>
+        </Map>
+        <ListOfOperations>
+          <Add id="RR1_PP1_M1"/>
+          <Delete id="RR1_RP1" DeleteMolecules="0"/>
+        </ListOfOperations>
+      </ReactionRule>
+    </ListOfReactionRules>
+    <ListOfObservables>
+      <Observable id="O1" name="Pn" type="Molecules" output="1">
+        <ListOfPatterns>
+          <Pattern id="O1_P1" automorphisms="1">
+            <ListOfMolecules>
+              <Molecule id="O1_P1_M1" name="P"/>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O2" name="Sn" type="Molecules" output="1">
+        <ListOfPatterns>
+          <Pattern id="O2_P1" automorphisms="1">
+            <ListOfMolecules>
+              <Molecule id="O2_P1_M1" name="S"/>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+    </ListOfObservables>
+    <ListOfFunctions>
+    </ListOfFunctions>
+  </model>
+</sbml>

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -457,6 +457,49 @@ class TestIssueRegressions(unittest.TestCase):
             "-sim 2 -oTimes 0,1,2 -seed 1",
         )
 
+    def test_mm_rate_law_survives_small_km_with_enzyme_in_excess(self):
+        # BioNetGen issue 323. The free substrate of the MM rate law used to be
+        # computed as 0.5*(b + sqrt(b*b + 4*Km*S)) with b = S - Km - E. That form
+        # cancels catastrophically for b < 0 and rounds to exactly zero once
+        # 4*Km*S drops below about 1e-16*b*b, leaving a propensity of zero and a
+        # reaction that never fires. With Km << E - S the free substrate is
+        # Km*S/(E-S) and the propensity reduces to kcat*S, so the substrate decays
+        # as a first order death process: P(t) = S0*(1 - exp(-kcat*t)).
+        xmlPath = os.path.join(nfsimPrePath, "test", "MM", "mm_small_km.xml")
+        S0, kcat, nSeeds = 100.0, 1.0, 20
+
+        total = None
+        headers = None
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for seed in range(1, nSeeds + 1):
+                outPath = os.path.join(tmpdir, "mm_{0}.gdat".format(seed))
+                self._run_nfsim_xml(xmlPath, outPath, "-sim 4 -oSteps 4 -seed {0}".format(seed))
+                headers, data = self._load_gdat(outPath)
+                total = data if total is None else total + data
+        mean = total / nSeeds
+
+        times = mean[:, headers.index("time")]
+        meanP = mean[:, headers.index("Pn")]
+        expected = S0 * (1.0 - np.exp(-kcat * times))
+
+        # The reaction fired at all. On the old expression every seed returns a
+        # flat zero trajectory, so this alone catches the regression.
+        self.assertTrue(
+            meanP[-1] > 0.0,
+            "MM rate law never fired for small Km with the enzyme in excess",
+        )
+        # Well clear of the stochastic spread: at t=1 the standard error of the
+        # mean over 20 seeds is about 1.7% of the expected value.
+        for t, got, want in zip(times[1:], meanP[1:], expected[1:]):
+            self.assertAlmostEqual(
+                got / want,
+                1.0,
+                delta=0.15,
+                msg="MM product at t={0} averaged {1} over {2} seeds, expected about {3}".format(
+                    t, got, nSeeds, want
+                ),
+            )
+
     def test_tfun_inline_time_outputs_expected_global_function(self):
         outputDirectory = mfolder
         fileNumber = "44"


### PR DESCRIPTION
Companion to RuleWorld/bionetgen#324, which fixed the same expression in Network3 and in the BioNetGen C++ engine. Reported as RuleWorld/bionetgen#323.

## The problem

`MMRxnClass::update_a` computed the free substrate as

```cpp
sFree=0.5*( (S-Km-E) + pow((pow( (S-Km-E),2.0) + 4.0*Km*S),  0.5) );
```

With `b = S - Km - E` negative, the square root is very close to `-b` and the sum cancels, so most of the significant digits are lost. Once `4*Km*S` falls below about `1e-16` of `b*b`, the sum rounds to exactly `0`, the propensity goes to zero, and the reaction never fires. That happens whenever `Km` is small and the enzyme is in excess, and it fails quietly: the reaction only slows down or goes dead.

## The fix

The two roots of `sFree^2 - b*sFree - Km*S = 0` multiply to `-Km*S`, so the non-negative root can equivalently be written `2*Km*S/(q - b)` with `q = sqrt(b*b + 4*Km*S)`. Selecting the branch on the sign of `b` makes both cases add like-signed quantities:

```cpp
double b = S-Km-E;
double q = sqrt(b*b + 4.0*Km*S);
sFree = (b>=0.0) ? 0.5*(b+q) : 2.0*Km*S/(q-b);
```

The `b >= 0` branch is the original expression, so results are unchanged wherever the old code was accurate.

## Verification

Substrate 100, enzyme 200, `kcat` 1. With `Km << E - S` the free substrate is `Km*S/(E-S)` and the propensity reduces to `kcat*S`, so the substrate decays as a first order death process and the mean product at `t = 1` is `100*(1 - exp(-1)) = 63.21`. Mean `Pn` at `t = 1` over 20 seeds:

| Km | master | with fix |
|---|---|---|
| 1e-8  | 61.85 | 61.85 |
| 1e-12 | 61.85 | 61.85 |
| 1e-13 | 61.25 | 61.85 |
| 1e-14 | 28.00 | 61.85 |
| 1e-15 |  0.00 | 61.85 |
| 1e-16 |  0.00 | 61.85 |

At `Km = 1e-15` master reports "You just simulated 0 reactions" and returns a flat trajectory.

`python validate/validate.py validate/.` passes all 62 tests locally.

## Tests

No model in `validate/basicModels` or `test/` used the MM rate law, so this code path had no coverage at all. Added:

* `test/MM/mm_small_km.{bngl,xml}` — the fixture above, `Km = 1e-15` with the enzyme at twice the substrate
* `test_mm_rate_law_survives_small_km_with_enzyme_in_excess` in `TestIssueRegressions` — averages 20 seeded runs and checks the product tracks `S0*(1 - exp(-kcat*t))` within 15%, well clear of the stochastic spread (the standard error of the mean over 20 seeds is about 1.7% at `t = 1`)

The test fails on master with "MM rate law never fired for small Km with the enzyme in excess" and passes with the fix.
