### PR TITLE
Four correctness fixes: symmetry factor, product molecularity, Species observables, and context counting

### DIFF
--- a/src/NFcore/NFcore.hh
+++ b/src/NFcore/NFcore.hh
@@ -1346,6 +1346,12 @@ namespace NFcore
 				return (reactantIndex < n_reactants) ? matchOncePerReactant[reactantIndex] : false;
 			}
 
+			/* True when this reactant's matches must be counted once per complex
+			 * rather than once per molecule; see contextCountsPerComplex below. */
+			bool getCountsPerComplex(unsigned int reactantIndex) const {
+				return (reactantIndex < n_reactants) ? contextCountsPerComplex[reactantIndex] : false;
+			}
+
 
 			void setRxnId(int rxnId) { this->rxnId = rxnId; };
 			int getRxnId() const { return rxnId; };
@@ -1451,6 +1457,17 @@ namespace NFcore
 
 			/* flag for MatchOnce */
 			bool *matchOncePerReactant;
+
+			/* True for a reactant the rule does not transform, when the system is
+			 * tracking complexes.  BioNetGen gives such a pattern one reaction
+			 * instance per matching COMPLEX, however many molecules inside that
+			 * complex match it, because every embedding yields the identical
+			 * reaction.  NFsim enumerates matches per molecule, so without this it
+			 * over-counts any multi-subunit context -- a homodimeric enzyme twice,
+			 * a homotrimer ring three times, a scaffold carrying two copies twice.
+			 * Requires complex bookkeeping: with it off every molecule reports
+			 * complex id -1 and there is no way to tell the cases apart. */
+			bool *contextCountsPerComplex;
 
 			/* if population reactants are identical, this is the discrete
 			 * count correction for calculating the ratelaw

--- a/src/NFcore/reactionClass.cpp
+++ b/src/NFcore/reactionClass.cpp
@@ -226,10 +226,34 @@ ReactionClass::ReactionClass(string name, double baseRate, string baseRateParame
 	// check for population type reactants
 	isPopulationType = new bool[n_reactants];
 	matchOncePerReactant = new bool[n_reactants];
+	contextCountsPerComplex = new bool[n_reactants];
 	for( unsigned int i=0; i < n_reactants; ++i )
 	{
 		isPopulationType[i] = reactantTemplates[i]->getMoleculeType()->isPopulationType();
 		matchOncePerReactant[i] = false;
+		contextCountsPerComplex[i] = false;
+	}
+
+	// Count a reactant the rule never transforms once per complex, as BNG does.
+	//
+	// BNG gives a pure context pattern one reaction instance per matching complex
+	// no matter how many molecules inside it match, because the reaction produced
+	// does not depend on which embedding was chosen -- same reactants, same
+	// products, same transformation.  Verified against BNG's generated network for
+	// a homodimer, a single subunit of that homodimer, a heterodimer, and a
+	// scaffold holding two *distinguishable* copies: all four get a bare rate
+	// constant.  A pattern the rule does transform is different and is left alone
+	// here: binding one of a homodimer's two sites really is two reactions, and
+	// BNG emits the factor of two for it.
+	//
+	// Only meaningful while complexes are tracked; see contextCountsPerComplex.
+	if( system->isUsingComplex() )
+	{
+		for( unsigned int i=0; i < n_reactants; ++i )
+		{
+			if( isPopulationType[i] ) continue;
+			contextCountsPerComplex[i] = transformationSet->isPureContextReactant(i);
+		}
 	}
 
 
@@ -292,6 +316,7 @@ ReactionClass::~ReactionClass()
 	delete [] mappingSet;
 	delete [] isPopulationType;
 	delete [] matchOncePerReactant;
+	delete [] contextCountsPerComplex;
 	delete [] identicalPopCountCorrection;
 	connectedReactions.clear();
 }

--- a/src/NFcore/reactionClass.cpp
+++ b/src/NFcore/reactionClass.cpp
@@ -178,9 +178,17 @@ ReactionClass::ReactionClass(string name, double baseRate, string baseRateParame
 		}
 	}
 
+	// Correct the rate for reaction center symmetry.  Note that these all assign
+	// through 'this->': the constructor argument 'baseRate' shadows the member,
+	// and the member was copied from it above, so scaling the argument here would
+	// discard the correction.  Only rate laws that route through setBaseRate()
+	// (which applies the factor itself) used to recover it; every other rate law
+	// -- global function, local function (DOR), function product, MM -- is
+	// constructed with baseRate=1 and never calls setBaseRate, so a symmetric
+	// rule fired at 1/symmetryFactor times its intended rate (2x for a homodimer).
 	if ( this->transformationSet->usingSymmetryFactor() )
 	{	// new general method for handling reaction center symmetry
-		baseRate *= this->transformationSet->getSymmetryFactor();
+		this->baseRate *= this->transformationSet->getSymmetryFactor();
 	}
 	else
 	{	// old method for handling symmetric binding and unbinding
@@ -193,7 +201,7 @@ ReactionClass::ReactionClass(string name, double baseRate, string baseRateParame
 				cout<<"Make sure that is correct."<<endl;
 
 				cout<<endl;
-				baseRate = baseRate*0.5;  //We have to correct the rate to get the proper factor
+				this->baseRate = this->baseRate*0.5;  //We have to correct the rate to get the proper factor
 				isDimerStyle=true;
 			}
 		}
@@ -205,7 +213,7 @@ ReactionClass::ReactionClass(string name, double baseRate, string baseRateParame
 				cout<<"Warning! You have an unbinding rxn (" << name << ") that is symmetric."<<endl;
 				cout<<"Make sure that is correct."<<endl;
 				cout<<endl;
-				baseRate = baseRate*0.5;  //We have to correct the rate to get the proper factor
+				this->baseRate = this->baseRate*0.5;  //We have to correct the rate to get the proper factor
 				isDimerStyle=true;
 			}
 		}

--- a/src/NFinput/NFinput.cpp
+++ b/src/NFinput/NFinput.cpp
@@ -46,6 +46,26 @@ component::~component()
 
 
 
+// Returns true if the model declares any Species-typed observable. Species
+// observables are tallied by iterating complexes, so the System must track
+// complexes (useComplex) for their counts to be correct. Detecting this from
+// the XML before the System is constructed lets complex tracking be enabled
+// independently of the -bscb policy.
+static bool modelHasSpeciesObservable(TiXmlElement *pModel)
+{
+	if (pModel == NULL) return false;
+	TiXmlElement *pListOfObservables = pModel->FirstChildElement("ListOfObservables");
+	if (pListOfObservables == NULL) return false;
+	for (TiXmlElement *pObs = pListOfObservables->FirstChildElement("Observable");
+			pObs != NULL; pObs = pObs->NextSiblingElement("Observable"))
+	{
+		const char *type = pObs->Attribute("type");
+		if (type != NULL && string(type) == "Species") return true;
+	}
+	return false;
+}
+
+
 System * NFinput::initializeFromXML(
 		string filename,
 		bool blockSameComplexBinding,
@@ -73,18 +93,31 @@ System * NFinput::initializeFromXML(
 		TiXmlElement *pModel = hDoc.FirstChildElement().Node()->FirstChildElement("model");
 		if(!pModel) { cout<<"\tNo 'model' tag found.  Quitting."; return NULL; }
 
+		// Decide whether the System must track complexes (useComplex). Two
+		// independent needs require it:
+		//   1. blockSameComplexBinding (-bscb): the same-complex binding /
+		//      molecularity policy needs complex membership to evaluate.
+		//   2. any Species-typed observable: those are counted by iterating
+		//      complexes, and their incremental count is only correct if complex
+		//      tracking is on from System construction (before molecules and
+		//      observables are built). Deriving useComplex from -bscb alone left
+		//      Species counts wildly inflated whenever same-complex binding was
+		//      allowed; the retroactive setUsingComplex() added for issue #49
+		//      fires too late to repair the already-wired incremental counters.
+		// Complex tracking (counting) is thus decoupled here from the -bscb
+		// policy, which stays governed by blockSameComplexBinding downstream
+		// (TransformationSet::setComplexBookkeeping).
+		bool useComplex = blockSameComplexBinding || modelHasSpeciesObservable(pModel);
+
 		//Make sure the basics are there
 		string modelName;
 		if(!pModel->Attribute("id"))  {
-			if(!blockSameComplexBinding) s=new System("nameless",false,globalMoleculeLimit);
-			else s=new System("nameless",true,globalMoleculeLimit);
+			s=new System("nameless",useComplex,globalMoleculeLimit);
 			if(verbose) cout<<"\tNo System name given, so I'm calling your system: "<<s->getName()<<endl;
 		}
 		else  {
 			modelName=pModel->Attribute("id");
-			//We have to add complex bookkeeping if we are blocking same complex binding
-			if(!blockSameComplexBinding) s=new System(modelName,false,globalMoleculeLimit);
-			else s=new System(modelName,true,globalMoleculeLimit);
+			s=new System(modelName,useComplex,globalMoleculeLimit);
 			if(verbose) cout<<"\tCreating system: "<<s->getName()<<endl;
 		}
 

--- a/src/NFreactions/reactantLists/reactantList.cpp
+++ b/src/NFreactions/reactantLists/reactantList.cpp
@@ -5,6 +5,7 @@ using namespace NFcore;
 
 ReactantList::ReactantList(unsigned int reactantIndex, TransformationSet *ts, unsigned int init_capacity=50)
 {
+	this->anyMultiMoleculeComplex = false;
 
 	this->n_mappingSets = 0;
 	this->capacity = init_capacity;

--- a/src/NFreactions/reactantLists/reactantList.hh
+++ b/src/NFreactions/reactantLists/reactantList.hh
@@ -55,6 +55,17 @@ namespace NFcore
 			 */
 			virtual int size() const { return n_mappingSets; };
 
+			/*! True once any molecule mapped into this container has belonged to a
+			    complex of more than one molecule.  While it is false no complex can
+			    hold two matches, so the distinct-complex count is just size() and the
+			    O(n) scan can be skipped -- which is the common case for catalytic
+			    rules over large monomer pools.  Conservative: a stale true only
+			    costs the scan. */
+			void noteMappedComplexSize(int complexSize) {
+				if (complexSize > 1) anyMultiMoleculeComplex = true;
+			}
+			bool mayShareComplexes() const { return anyMultiMoleculeComplex; }
+
 			/*!
 				Returns the sum population of all mappingSets that have been added to this list
 			 */
@@ -117,6 +128,7 @@ namespace NFcore
 
 			/*! Maintains the number of mappingSets on this list */
 			int n_mappingSets;
+			bool anyMultiMoleculeComplex;
 
 			/*! The total capacity that this list can hold */
 			int capacity;

--- a/src/NFreactions/reactantLists/reactantTree.cpp
+++ b/src/NFreactions/reactantLists/reactantTree.cpp
@@ -17,6 +17,7 @@ ReactantTree::ReactantTree(
 		TransformationSet *ts,
 		unsigned int init_capacity)
 {
+	this->anyMultiMoleculeComplex = false;
 
 	//First set basic properties of the tree
 	this->reactantIndex=reactantIndex;

--- a/src/NFreactions/reactantLists/reactantTree.hh
+++ b/src/NFreactions/reactantLists/reactantTree.hh
@@ -102,6 +102,25 @@ namespace NFcore
 			 */
 			virtual MappingSet * getMappingSet(unsigned int mappingSetId) const;
 
+			/*!
+				Returns the MappingSet at a position in the flat mappingSets array, so
+				callers can walk the live entries alongside getRateFactor(), which is
+				indexed the same way.  ReactantList offers the same accessor.
+				
+			 */
+			virtual MappingSet * getMappingSetByIndex(unsigned int index) const { return mappingSets[index]; }
+
+			/*! True once any molecule mapped into this container has belonged to a
+			    complex of more than one molecule.  While it is false no complex can
+			    hold two matches, so the distinct-complex count is just size() and the
+			    O(n) scan can be skipped -- which is the common case for catalytic
+			    rules over large monomer pools.  Conservative: a stale true only
+			    costs the scan. */
+			void noteMappedComplexSize(int complexSize) {
+				if (complexSize > 1) anyMultiMoleculeComplex = true;
+			}
+			bool mayShareComplexes() const { return anyMultiMoleculeComplex; }
+
 
 
 			/*!
@@ -151,6 +170,7 @@ namespace NFcore
 			unsigned int navigateAndInsertTree(unsigned int firstTreeIndex, int* lElementCount, int* rElementCount, double* lRateFactorSum, double rateFactor);
 
 
+			bool anyMultiMoleculeComplex;
 			TransformationSet *ts;       //Keeps track of the set of transformations
 			unsigned int reactantIndex;  //the index of the tree
 

--- a/src/NFreactions/reactions/DORreaction.cpp
+++ b/src/NFreactions/reactions/DORreaction.cpp
@@ -225,6 +225,10 @@ int DORRxnClass::checkForCollision(Molecule *m, MappingSet* ms, int rxnIndex){
 }
 
 bool DORRxnClass::tryToAdd(Molecule *m, unsigned int reactantPos) {
+	// see BasicRxnClass::tryToAdd()
+	if (contextCountsPerComplex[reactantPos] && reactantPos == (unsigned)DORreactantIndex) {
+		reactantTree->noteMappedComplexSize(m->getComplex()->getComplexSize());
+	}
 	if(reactantPos==(unsigned)this->DORreactantIndex) {
 
 		// handle the DOR reactant
@@ -415,23 +419,17 @@ int DORRxnClass::getReactantCount(unsigned int reactantIndex) const
 int DORRxnClass::getCorrectedReactantCount(unsigned int reactantIndex) const
 {
 	if(reactantIndex==(unsigned)this->DORreactantIndex) {
-		return reactantTree->size();
+		return contextCountsPerComplex[reactantIndex]
+		         ? countDistinctComplexes(reactantTree)
+		         : reactantTree->size();
 	}
 
-	if (matchOncePerReactant[reactantIndex] && !isPopulationType[reactantIndex]) {
-		std::set<int> uniqueComplexes;
-		ReactantList *rl = reactantLists[reactantIndex];
-		int size = rl->size();
-		for (int i = 0; i < size; ++i) {
-			MappingSet *ms = rl->getMappingSetByIndex(i);
-			if (ms && ms->getNumOfMappings() > 0) {
-				Mapping *mapping = ms->get(0);
-				if (mapping && mapping->getMolecule()) {
-					uniqueComplexes.insert(mapping->getMolecule()->getComplexID());
-				}
-			}
-		}
-		return (int)uniqueComplexes.size();
+	// MatchOnce is the user's explicit request; contextCountsPerComplex is the
+	// same counting applied automatically to a reactant the rule never transforms,
+	// which is how BNG counts one.
+	if ((matchOncePerReactant[reactantIndex] || contextCountsPerComplex[reactantIndex])
+	    && !isPopulationType[reactantIndex]) {
+		return countDistinctComplexes(reactantLists[reactantIndex]);
 	}
 
 	return isPopulationType[reactantIndex] ?
@@ -527,7 +525,11 @@ double DORRxnClass::update_a() {
 		if(i!=DORreactantIndex) {
 			a*=(double)getCorrectedReactantCount(i);
 		} else {
-			a*=reactantTree->getRateFactorSum();
+			// This reactant's propensity comes from the tree's rate factor sum, not
+			// from a count, so per-complex counting has to be applied to the sum.
+			a *= contextCountsPerComplex[i]
+			       ? perComplexRateFactorSum(reactantTree)
+			       : reactantTree->getRateFactorSum();
 		}
 	}
 	return a;
@@ -548,35 +550,48 @@ double DORRxnClass::exactRuleMonkey_a()
 		validCombinations = 1.0;
 	} else if (n_reactants == 1) {
 		if (0 == DORreactantIndex) {
-			validCombinations = reactantTree->getRateFactorSum();
+			// A DOR reactant's propensity comes from its tree's rate factor sum
+			// rather than from a count, so per-complex counting is applied there;
+			// see DORRxnClass::update_a().
+			validCombinations = contextCountsPerComplex[0]
+			                      ? perComplexRateFactorSum(reactantTree)
+			                      : reactantTree->getRateFactorSum();
 		} else {
 			validCombinations = getCorrectedReactantCount(0);
 		}
 	} else if (n_reactants == 2) {
-		int size0 = getReactantCount(0);
-		int size1 = getReactantCount(1);
+		// One representative per complex for a pure context reactant, as in
+		// BasicRxnClass::exactRuleMonkey_a(), so the enumerated pairs match the
+		// counts and rate factor sums the total is built from.
+		static thread_local std::vector<MappingSet*> reps0, reps1;
+		static thread_local std::vector<int> idx0, idx1;
+		collectReactantRepresentatives(reactantLists[0], contextCountsPerComplex[0], reps0, &idx0);
+		collectReactantRepresentatives(reactantLists[1], contextCountsPerComplex[1], reps1, &idx1);
+
 		double totalCombinations = 1.0;
 		for(unsigned int i=0; i<n_reactants; i++) {
 			if(i!=DORreactantIndex) {
-				totalCombinations*=(double)getReactantCount(i);
+				totalCombinations*=(double)getCorrectedReactantCount(i);
 			} else {
-				totalCombinations*=reactantTree->getRateFactorSum();
+				totalCombinations *= contextCountsPerComplex[i]
+				                       ? perComplexRateFactorSum(reactantTree)
+				                       : reactantTree->getRateFactorSum();
 			}
 		}
 
 		double invalidCombinations = 0;
 
-		for (int i = 0; i < size0; ++i) {
-			msPairBuffer[0] = reactantLists[0]->getMappingSet(i);
-			for (int j = 0; j < size1; ++j) {
-				msPairBuffer[1] = reactantLists[1]->getMappingSet(j);
-				
+		for (size_t i = 0; i < reps0.size(); ++i) {
+			msPairBuffer[0] = reps0[i];
+			for (size_t j = 0; j < reps1.size(); ++j) {
+				msPairBuffer[1] = reps1[j];
+
 				if (!transformationSet->checkMolecularity(msPairBuffer)) {
 					double weight = 1.0;
 					if (0 == DORreactantIndex) {
-						weight = reactantTree->getRateFactor(i);
+						weight = reactantTree->getRateFactor(idx0[i]);
 					} else if (1 == DORreactantIndex) {
-						weight = reactantTree->getRateFactor(j);
+						weight = reactantTree->getRateFactor(idx1[j]);
 					}
 					invalidCombinations += weight;
 				}
@@ -590,7 +605,9 @@ double DORRxnClass::exactRuleMonkey_a()
 			if(i!=DORreactantIndex) {
 				validCombinations*=(double)getCorrectedReactantCount(i);
 			} else {
-				validCombinations*=reactantTree->getRateFactorSum();
+				validCombinations *= contextCountsPerComplex[i]
+				                       ? perComplexRateFactorSum(reactantTree)
+				                       : reactantTree->getRateFactorSum();
 			}
 		}
 	}
@@ -1181,26 +1198,20 @@ int DOR2RxnClass::getReactantCount(unsigned int reactantIndex) const
 int DOR2RxnClass::getCorrectedReactantCount(unsigned int reactantIndex) const
 {
 	if (reactantIndex==(unsigned)DORreactantIndex1) {
-		return reactantTree1->size();
+		return contextCountsPerComplex[reactantIndex]
+		         ? countDistinctComplexes(reactantTree1) : reactantTree1->size();
 	}
 	else if (reactantIndex==(unsigned)DORreactantIndex2) {
-		return reactantTree2->size();
+		return contextCountsPerComplex[reactantIndex]
+		         ? countDistinctComplexes(reactantTree2) : reactantTree2->size();
 	}
 
-	if (matchOncePerReactant[reactantIndex] && !isPopulationType[reactantIndex]) {
-		std::set<int> uniqueComplexes;
-		ReactantList *rl = reactantLists[reactantIndex];
-		int size = rl->size();
-		for (int i = 0; i < size; ++i) {
-			MappingSet *ms = rl->getMappingSetByIndex(i);
-			if (ms && ms->getNumOfMappings() > 0) {
-				Mapping *mapping = ms->get(0);
-				if (mapping && mapping->getMolecule()) {
-					uniqueComplexes.insert(mapping->getMolecule()->getComplexID());
-				}
-			}
-		}
-		return (int)uniqueComplexes.size();
+	// MatchOnce is the user's explicit request; contextCountsPerComplex is the
+	// same counting applied automatically to a reactant the rule never transforms,
+	// which is how BNG counts one.
+	if ((matchOncePerReactant[reactantIndex] || contextCountsPerComplex[reactantIndex])
+	    && !isPopulationType[reactantIndex]) {
+		return countDistinctComplexes(reactantLists[reactantIndex]);
 	}
 
 	return isPopulationType[reactantIndex] ?
@@ -1282,11 +1293,17 @@ double DOR2RxnClass::update_a() {
 	}
 	a = baseRate;
 	for (unsigned int i=0; i<n_reactants; i++) {
+		// as in DORRxnClass::update_a(), a DOR reactant's propensity comes from its
+		// rate factor sum, so that is where per-complex counting goes
 		if (i==(unsigned int)DORreactantIndex1) {
-			a*=reactantTree1->getRateFactorSum();
+			a *= contextCountsPerComplex[i]
+			       ? perComplexRateFactorSum(reactantTree1)
+			       : reactantTree1->getRateFactorSum();
 		}
 		else if (i==(unsigned int)DORreactantIndex2) {
-			a*=reactantTree2->getRateFactorSum();
+			a *= contextCountsPerComplex[i]
+			       ? perComplexRateFactorSum(reactantTree2)
+			       : reactantTree2->getRateFactorSum();
 		}
 		else {
 			a*=(double)getCorrectedReactantCount(i);
@@ -1310,39 +1327,54 @@ double DOR2RxnClass::exactRuleMonkey_a()
 	if (n_reactants == 0) {
 		validCombinations = 1.0;
 	} else if (n_reactants == 1) {
+		// As in DORRxnClass, a DOR reactant's propensity comes from its tree's
+		// rate factor sum, so that is where per-complex counting is applied.
 		if (0 == DORreactantIndex1) {
-			validCombinations = reactantTree1->getRateFactorSum();
+			validCombinations = contextCountsPerComplex[0]
+			                      ? perComplexRateFactorSum(reactantTree1)
+			                      : reactantTree1->getRateFactorSum();
 		} else if (0 == DORreactantIndex2) {
-			validCombinations = reactantTree2->getRateFactorSum();
+			validCombinations = contextCountsPerComplex[0]
+			                      ? perComplexRateFactorSum(reactantTree2)
+			                      : reactantTree2->getRateFactorSum();
 		} else {
 			validCombinations = getCorrectedReactantCount(0);
 		}
 	} else if (n_reactants == 2) {
-		int size0 = getReactantCount(0);
-		int size1 = getReactantCount(1);
+		// One representative per complex for a pure context reactant, as in
+		// BasicRxnClass::exactRuleMonkey_a().
+		static thread_local std::vector<MappingSet*> reps0, reps1;
+		static thread_local std::vector<int> idx0, idx1;
+		collectReactantRepresentatives(reactantLists[0], contextCountsPerComplex[0], reps0, &idx0);
+		collectReactantRepresentatives(reactantLists[1], contextCountsPerComplex[1], reps1, &idx1);
+
 		double totalCombinations = 1.0;
 		for (unsigned int i=0; i<n_reactants; i++) {
 			if (i==(unsigned int)DORreactantIndex1) {
-				totalCombinations*=reactantTree1->getRateFactorSum();
+				totalCombinations *= contextCountsPerComplex[i]
+				                       ? perComplexRateFactorSum(reactantTree1)
+				                       : reactantTree1->getRateFactorSum();
 			} else if (i==(unsigned int)DORreactantIndex2) {
-				totalCombinations*=reactantTree2->getRateFactorSum();
+				totalCombinations *= contextCountsPerComplex[i]
+				                       ? perComplexRateFactorSum(reactantTree2)
+				                       : reactantTree2->getRateFactorSum();
 			} else {
-				totalCombinations*=(double)getReactantCount(i);
+				totalCombinations*=(double)getCorrectedReactantCount(i);
 			}
 		}
 
 		double invalidCombinations = 0;
 
-		for (int i = 0; i < size0; ++i) {
-			msPairBuffer[0] = reactantLists[0]->getMappingSet(i);
-			for (int j = 0; j < size1; ++j) {
-				msPairBuffer[1] = reactantLists[1]->getMappingSet(j);
-				
+		for (size_t i = 0; i < reps0.size(); ++i) {
+			msPairBuffer[0] = reps0[i];
+			for (size_t j = 0; j < reps1.size(); ++j) {
+				msPairBuffer[1] = reps1[j];
+
 				if (!transformationSet->checkMolecularity(msPairBuffer)) {
-					double weight0 = (0 == DORreactantIndex1) ? reactantTree1->getRateFactor(i) :
-					                 ((0 == DORreactantIndex2) ? reactantTree2->getRateFactor(i) : 1.0);
-					double weight1 = (1 == DORreactantIndex1) ? reactantTree1->getRateFactor(j) :
-					                 ((1 == DORreactantIndex2) ? reactantTree2->getRateFactor(j) : 1.0);
+					double weight0 = (0 == DORreactantIndex1) ? reactantTree1->getRateFactor(idx0[i]) :
+					                 ((0 == DORreactantIndex2) ? reactantTree2->getRateFactor(idx0[i]) : 1.0);
+					double weight1 = (1 == DORreactantIndex1) ? reactantTree1->getRateFactor(idx1[j]) :
+					                 ((1 == DORreactantIndex2) ? reactantTree2->getRateFactor(idx1[j]) : 1.0);
 					invalidCombinations += (weight0 * weight1);
 				}
 			}
@@ -1353,9 +1385,13 @@ double DOR2RxnClass::exactRuleMonkey_a()
 		validCombinations = 1.0;
 		for (unsigned int i=0; i<n_reactants; i++) {
 			if (i==(unsigned int)DORreactantIndex1) {
-				validCombinations*=reactantTree1->getRateFactorSum();
+				validCombinations *= contextCountsPerComplex[i]
+				                       ? perComplexRateFactorSum(reactantTree1)
+				                       : reactantTree1->getRateFactorSum();
 			} else if (i==(unsigned int)DORreactantIndex2) {
-				validCombinations*=reactantTree2->getRateFactorSum();
+				validCombinations *= contextCountsPerComplex[i]
+				                       ? perComplexRateFactorSum(reactantTree2)
+				                       : reactantTree2->getRateFactorSum();
 			} else {
 				validCombinations*=(double)getCorrectedReactantCount(i);
 			}

--- a/src/NFreactions/reactions/reaction.cpp
+++ b/src/NFreactions/reactions/reaction.cpp
@@ -246,6 +246,110 @@ void MMRxnClass::printDetails() const {
 
 
 
+/* --- pure context counting, shared by every reaction class ------------------
+ *
+ * BioNetGen gives a reactant pattern the rule does not transform one reaction
+ * instance per matching COMPLEX, however many molecules in that complex match
+ * it: every embedding produces the identical reaction, so there is only one.
+ * NFsim enumerates matches per molecule, so these collapse the difference.
+ * Both read the complex off mapping 0, which for such a reactant is the root
+ * molecule placed by the placeholder transform TransformationSet::finalize()
+ * adds. */
+
+/* Scratch buffer for the counts below.  These run on the propensity hot path --
+ * once per reactant per update_a(), which is millions of calls on a model with a
+ * catalytic rule -- so they must not allocate.  A reused vector plus sort beats
+ * building a std::set by more than an order of magnitude, and thread_local keeps
+ * concurrent sessions from sharing it. */
+static thread_local std::vector<int> s_complexScratch;
+
+template <typename Container>
+static int distinctComplexesOf(Container *rc, int size)
+{
+	s_complexScratch.clear();
+	if ((int)s_complexScratch.capacity() < size) s_complexScratch.reserve(size);
+	for (int i = 0; i < size; ++i) {
+		MappingSet *ms = rc->getMappingSetByIndex(i);
+		if (ms && ms->getNumOfMappings() > 0) {
+			Mapping *mapping = ms->get(0);
+			if (mapping && mapping->getMolecule()) {
+				s_complexScratch.push_back(mapping->getMolecule()->getComplexID());
+			}
+		}
+	}
+	std::sort(s_complexScratch.begin(), s_complexScratch.end());
+	return (int)(std::unique(s_complexScratch.begin(), s_complexScratch.end())
+	             - s_complexScratch.begin());
+}
+
+int NFcore::countDistinctComplexes(ReactantList *rl)
+{
+	if (!rl->mayShareComplexes()) return rl->size();
+	return distinctComplexesOf(rl, rl->size());
+}
+
+int NFcore::countDistinctComplexes(ReactantTree *tree)
+{
+	if (!tree->mayShareComplexes()) return tree->size();
+	return distinctComplexesOf(tree, tree->size());
+}
+
+double NFcore::perComplexRateFactorSum(ReactantTree *tree)
+{
+	// One representative term per complex.  getRateFactor() is indexed by the
+	// same flat array position as getMappingSetByIndex(), so this walks the live
+	// entries and keeps the first seen for each complex.
+	std::set<int> seen;
+	double sum = 0.0;
+	int size = tree->size();
+	for (int i = 0; i < size; ++i) {
+		MappingSet *ms = tree->getMappingSetByIndex(i);
+		if (!ms || ms->getNumOfMappings() == 0) continue;
+		Mapping *mapping = ms->get(0);
+		if (!mapping || !mapping->getMolecule()) continue;
+		if (seen.insert(mapping->getMolecule()->getComplexID()).second) {
+			sum += tree->getRateFactor(i);
+		}
+	}
+	return sum;
+}
+
+void NFcore::collectReactantRepresentatives(ReactantList *rl, bool perComplex,
+                                            std::vector<MappingSet*> &out,
+                                            std::vector<int> *flatIndices)
+{
+	out.clear();
+	if (flatIndices) flatIndices->clear();
+	int size = rl->size();
+
+	// Nothing to collapse: either this reactant is transformed by the rule, or
+	// every match sits in a single-molecule complex and one match already is one
+	// complex.  Enumerate every live mapping set, exactly as before.
+	if (!perComplex || !rl->mayShareComplexes()) {
+		for (int i = 0; i < size; ++i) {
+			MappingSet *ms = rl->getMappingSetByIndex(i);
+			if (ms) {
+				out.push_back(ms);
+				if (flatIndices) flatIndices->push_back(i);
+			}
+		}
+		return;
+	}
+
+	std::set<int> seen;
+	for (int i = 0; i < size; ++i) {
+		MappingSet *ms = rl->getMappingSetByIndex(i);
+		if (!ms || ms->getNumOfMappings() == 0) continue;
+		Mapping *mapping = ms->get(0);
+		if (!mapping || !mapping->getMolecule()) continue;
+		if (seen.insert(mapping->getMolecule()->getComplexID()).second) {
+			out.push_back(ms);
+			if (flatIndices) flatIndices->push_back(i);
+		}
+	}
+}
+
+
 BasicRxnClass::BasicRxnClass(string name, double baseRate, string baseRateName, TransformationSet *transformationSet, System *s) :
 	ReactionClass(name,baseRate,baseRateName,transformationSet,s)
 {
@@ -375,6 +479,13 @@ bool BasicRxnClass::tryToAdd(Molecule *m, unsigned int reactantPos)
 	//Here we get the standard update...
 	set<int> deleteMs = m->getRxnListMappingSet(rxnIndex);
 
+	// Cheap note for countDistinctComplexes(): while every matched molecule is a
+	// singleton complex, no complex can hold two matches and the distinct-complex
+	// count is just size().
+	if (contextCountsPerComplex[reactantPos]) {
+		rl->noteMappedComplexSize(m->getComplex()->getComplexSize());
+	}
+
 	//Try to map it!
 	MappingSet *ms = rl->pushNextAvailableMappingSet();
 	symmetricMappingSet.clear();
@@ -480,18 +591,24 @@ double BasicRxnClass::exactRuleMonkey_a()
 	} else if (n_reactants == 1) {
 		validCombinations = getCorrectedReactantCount(0);
 	} else if (n_reactants == 2) {
-		// Exact calculation: subtract null events
-		int size0 = getReactantCount(0);
-		int size1 = getReactantCount(1);
+		// Exact calculation: subtract null events.  Enumerate one representative
+		// per complex for a reactant the rule does not transform, so both the
+		// total and the invalid pairs subtracted from it are counted on the same
+		// footing as getCorrectedReactantCount(); for every other reactant this
+		// is still every live mapping set, and the arithmetic is unchanged.
+		static thread_local std::vector<MappingSet*> reps0, reps1;
+		collectReactantRepresentatives(reactantLists[0], contextCountsPerComplex[0], reps0);
+		collectReactantRepresentatives(reactantLists[1], contextCountsPerComplex[1], reps1);
+
 		// Use raw counts here because invalid self-pairs are removed explicitly below.
-		double totalCombinations = (double)getReactantCount(0) * (double)getReactantCount(1);
+		double totalCombinations = (double)reps0.size() * (double)reps1.size();
 		double invalidCombinations = 0;
 
-		for (int i = 0; i < size0; ++i) {
-			msPairBuffer[0] = reactantLists[0]->getMappingSet(i);
-			for (int j = 0; j < size1; ++j) {
-				msPairBuffer[1] = reactantLists[1]->getMappingSet(j);
-				
+		for (size_t i = 0; i < reps0.size(); ++i) {
+			msPairBuffer[0] = reps0[i];
+			for (size_t j = 0; j < reps1.size(); ++j) {
+				msPairBuffer[1] = reps1[j];
+
 				// check for collision
 				if (!transformationSet->checkMolecularity(msPairBuffer)) {
 					invalidCombinations++;
@@ -559,20 +676,12 @@ int BasicRxnClass::getCorrectedReactantCount(unsigned int reactantIndex) const
 	}
 	*/
 
-	if (matchOncePerReactant[reactantIndex] && !isPopulationType[reactantIndex]) {
-		std::set<int> uniqueComplexes;
-		ReactantList *rl = reactantLists[reactantIndex];
-		int size = rl->size();
-		for (int i = 0; i < size; ++i) {
-			MappingSet *ms = rl->getMappingSetByIndex(i);
-			if (ms && ms->getNumOfMappings() > 0) {
-				Mapping *mapping = ms->get(0);
-				if (mapping && mapping->getMolecule()) {
-					uniqueComplexes.insert(mapping->getMolecule()->getComplexID());
-				}
-			}
-		}
-		return (int)uniqueComplexes.size();
+	// MatchOnce is the user's explicit request; contextCountsPerComplex is the
+	// same counting applied automatically to a reactant the rule never transforms,
+	// which is how BNG counts one.
+	if ((matchOncePerReactant[reactantIndex] || contextCountsPerComplex[reactantIndex])
+	    && !isPopulationType[reactantIndex]) {
+		return countDistinctComplexes(reactantLists[reactantIndex]);
 	}
 
 	return isPopulationType[reactantIndex] ?

--- a/src/NFreactions/reactions/reaction.cpp
+++ b/src/NFreactions/reactions/reaction.cpp
@@ -79,6 +79,13 @@ double FunctionalRxnClass::update_a() {
 
 	a *= this->volumeConversionFactor;
 
+	// Scale by baseRate, exactly as BasicRxnClass/DORRxnClass/DOR2RxnClass do.
+	// A FunctionalRxnClass is constructed with baseRate=1 and never routes
+	// through setBaseRate(), so this factor is the reaction center symmetry
+	// correction and nothing else.  Without it a symmetric rule with a
+	// functional rate fires at 1/symmetryFactor times its intended rate.
+	a *= this->baseRate;
+
 	if(a<0) {
 		cout<<"Warning!!  The function you provided for functional rxn: '"<<name<<"' evaluates\n";
 		cout<<"to a value less than zero!  You cannot have a negative propensity!";
@@ -185,7 +192,27 @@ double MMRxnClass::exactRuleMonkey_a()
 
 double MMRxnClass::update_a()
 {
-	double S = (double)getCorrectedReactantCount(0);
+	// See FunctionalRxnClass::update_a() -- an MMRxnClass is likewise built with
+	// baseRate=1 and never calls setBaseRate(), so baseRate carries the reaction
+	// center symmetry correction.  BNG emits symmetry_factor with an MM rate law
+	// whenever the substrate pattern has a non-trivial automorphism.
+	//
+	// It belongs on the substrate COUNT, inside the law -- not on the finished
+	// propensity.  What the factor corrects is a match multiplicity:
+	// getCorrectedReactantCount(0) counts pattern embeddings, and a substrate
+	// pattern with a non-trivial automorphism matches each complex more than
+	// once, so the law is being handed more substrate than exists.  Michaelis-
+	// Menten is not linear in that count, so scaling the finished propensity
+	// instead is exact only below saturation; scaling the count is exact
+	// everywhere, and the two agree wherever the law is linear.
+	//
+	// Only the substrate needs it. The enzyme is pure context here -- an MM rule
+	// does not transform it -- and BNG's MultScale counts reaction-center
+	// automorphisms, so it emits symmetry_factor=1 for an enzyme-side symmetry
+	// and this factor is always the substrate's. (NFsim does over-count a
+	// symmetric context pattern, but that is a separate defect with no
+	// symmetry_factor attached to it; see issue #87.)
+	double S = (double)getCorrectedReactantCount(0) * this->baseRate;
 	double E = (double)getCorrectedReactantCount(1);
 	// Free substrate is the non-negative root of sFree^2 - b*sFree - Km*S = 0, b = S-Km-E.
 	// The textbook form 0.5*(b + sqrt(b*b + 4*Km*S)) cancels catastrophically when b < 0,

--- a/src/NFreactions/reactions/reaction.hh
+++ b/src/NFreactions/reactions/reaction.hh
@@ -12,6 +12,31 @@ using namespace std;
 namespace NFcore
 {
 
+	/* Helpers for counting a pure context reactant the way BioNetGen does: one
+	 * reaction instance per matching complex rather than one per matching
+	 * molecule.  See ReactionClass::contextCountsPerComplex. */
+
+	/*! Number of distinct complexes represented among a reactant list's matches. */
+	int countDistinctComplexes(ReactantList *rl);
+
+	/*! Same, for a DOR reactant's tree. */
+	int countDistinctComplexes(ReactantTree *tree);
+
+	/*! Sum of one representative rate factor per distinct complex in a DOR tree.
+	    Exact: it sums the same terms BNG would count instances for. */
+	double perComplexRateFactorSum(ReactantTree *tree);
+
+	/*! Fills `out` with the mapping sets to enumerate for one reactant of a
+	    RuleMonkey-exact pair count.  Ordinarily that is every live mapping set;
+	    for a pure context reactant it is one representative per complex, so that
+	    the enumerated pairs are counted on the same footing as
+	    getCorrectedReactantCount().  `flatIndices`, when non-null, receives each
+	    kept mapping set's flat array position, which a DOR caller needs to look
+	    up the matching rate factor. */
+	void collectReactantRepresentatives(ReactantList *rl, bool perComplex,
+	                                    std::vector<MappingSet*> &out,
+	                                    std::vector<int> *flatIndices = 0);
+
 	class BasicRxnClass : public ReactionClass {
 		public:
 			BasicRxnClass(string name, double baseRate, string baseRateName, TransformationSet *transformationSet, System *s);

--- a/src/NFreactions/transformations/transformationSet.cpp
+++ b/src/NFreactions/transformations/transformationSet.cpp
@@ -922,11 +922,35 @@ MappingSet *TransformationSet::generateBlankMappingSet(unsigned int reactantInde
 	return new MappingSet(mappingSetId, transformations[reactantIndex]);
 }
 
+
+bool TransformationSet::isPureContextReactant(unsigned int reactantIndex) const
+{
+	if( reactantIndex >= n_reactants ) return false;
+	return pureContextReactants.find(reactantIndex) != pureContextReactants.end();
+}
+
+
 void TransformationSet::finalize()
 {
 	//Be sure to add at least a blank transformation to every reactant if there is no transformation
 	//specified so that we count the reactants even if we don't do anything to it.
 	for(unsigned int r=0; r<getNmappingSets(); r++)  {
+
+		// Record which reactants the rule does not transform, before the placeholder
+		// below makes that indistinguishable.  EMPTY cannot be the test: it is also
+		// what genBindingTransform2() puts on the second partner of a binding, which
+		// very much is a reaction center.  A LOCAL_FUNCTION_REFERENCE, on the other
+		// hand, only marks the molecule a local function reads, so a DOR reactant
+		// can still be pure context.
+		bool pureContext = true;
+		for(unsigned int t=0; t<transformations[r].size(); t++) {
+			if(transformations[r].at(t)->getType() != (int)TransformationFactory::LOCAL_FUNCTION_REFERENCE) {
+				pureContext = false;
+				break;
+			}
+		}
+		if(pureContext) pureContextReactants.insert(r);
+
 		if(transformations[r].size()==0) {
 			transformations[r].push_back(TransformationFactory::genEmptyTransform());
 			MapGenerator *mg = new MapGenerator(transformations[r].size()-1);

--- a/src/NFreactions/transformations/transformationSet.cpp
+++ b/src/NFreactions/transformations/transformationSet.cpp
@@ -474,47 +474,63 @@ bool TransformationSet::addAddMolecule( MoleculeCreator *mc )
 
 
 
-bool TransformationSet::canReachExcludingBond(Molecule *mol1, Molecule *mol2, int excludeComponentIndex)
+bool TransformationSet::canReachExcludingBonds(Molecule *mol1, Molecule *mol2,
+		const std::vector< std::pair<Molecule *, int> > &excludedBonds)
 {
-	// Perform a BFS from mol2 to see if mol1 is reachable while excluding
-	// the specific bond at excludeComponentIndex on mol2.
-	// Returns true if mol1 can be reached, false otherwise.
-	
-	int excludeComponentIndexMol2 = mol1->getBondedMoleculeBindingSiteIndex(excludeComponentIndex);
-	
-	queue <Molecule *> q;
-	list <Molecule *> visited;
-	
+	// Perform a BFS from mol2 to see if mol1 is reachable while refusing to
+	// traverse any of the bonds in excludedBonds. Each excluded bond is recorded
+	// as both of its (molecule, component-index) half-edges, so the bond is
+	// skipped regardless of which endpoint the BFS reaches first.
+	// Returns true if mol1 can still be reached, false otherwise.
+	//
+	// Excluding the full set of bonds that the firing rule deletes (rather than
+	// one bond at a time) is what lets a multi-bond ring-opening dissociation be
+	// recognized as genuinely separating its products: each individual bond may
+	// leave the partners connected, while removing all of them does not.
+
+	// Use a static queue for efficiency (reusing the BFS infrastructure)
+	static queue <Molecule *> q;
+	static list <Molecule *> visited;
+
+	// Clear queues and visited list
+	while(!q.empty()) q.pop();
+	visited.clear();
 	// Start BFS from mol2
 	q.push(mol2);
 	visited.push_back(mol2);
 	mol2->setVisitedMolecule(true);
 
 	bool found = false;
-	
+
 	while(!q.empty()) {
 		Molecule *current = q.front();
 		q.pop();
-		
+
 		// Check if we reached mol1
 		if (current == mol1) {
 			found = true;
 			break;
 		}
-		
+
 		// Explore neighbors through bonds
 		int numComponents = current->getMoleculeType()->getNumOfComponents();
 		for (int c = 0; c < numComponents; ++c) {
-			// Skip the excluded bond from both endpoints.
-			if ((current == mol1 && c == excludeComponentIndex) ||
-			    (current == mol2 && c == excludeComponentIndexMol2)) {
+			// Skip any half-edge belonging to a bond the rule will delete.
+			bool isExcluded = false;
+			for (unsigned int e = 0; e < excludedBonds.size(); ++e) {
+				if (excludedBonds[e].first == current && excludedBonds[e].second == c) {
+					isExcluded = true;
+					break;
+				}
+			}
+			if (isExcluded) {
 				continue;
 			}
-			
+
 			// Check if this component is bonded
 			if (current->isBindingSiteBonded(c)) {
 				Molecule *neighbor = current->getBondedMolecule(c);
-				
+
 				// Check if we've already visited this neighbor
 				if (!neighbor->getVisitedMolecule()) {
 					// Haven't visited this neighbor yet
@@ -687,54 +703,66 @@ bool TransformationSet::checkMolecularity( MappingSet ** mappingSets )
 		// Issue #48: NFsim does not enforce product molecularity for unimolecular unbinding rules
 		if ( n_reactants == 1 && complex_bookkeeping && n_product_patterns > 1 )
 		{
-			// Check each transformation for unbinding that would violate product molecularity
+			// First pass: gather every bond this rule's UNBINDING transforms will
+			// delete. The connectivity test below must reflect the post-reaction
+			// graph with ALL of them removed at once. Testing each bond in
+			// isolation wrongly blocks multi-bond ring-opening dissociations
+			// (e.g. a symmetric two-bond homodimer splitting into two monomers):
+			// each single bond's removal leaves the partners connected through
+			// the rule's other deleted bond, even though removing both genuinely
+			// separates the products.
+			std::vector< std::pair<Molecule *, int> > excludedBonds;       // half-edges
+			std::vector< std::pair<Molecule *, Molecule *> > brokenPairs;  // endpoints to test
 			for ( unsigned int t = 0; t < getNumOfTransformations(0); ++t )
 			{
 				Transformation * transform = getTransformation(0, t);
-				if ( transform->getType() == TransformationFactory::UNBINDING )
-				{
-					UnbindingTransform * unbindingTransform = 
-						static_cast<UnbindingTransform *>( transform );
-					
-					Mapping * mapping = mappingSets[0]->get(t);
-					if (mapping == NULL) {
-						continue;
-					}
+				if ( transform->getType() != TransformationFactory::UNBINDING )
+					continue;
 
-					// Get the molecule that will be unbound
-					Molecule * mol = mapping->getMolecule();
-					if (mol == NULL) {
-						continue;
-					}
-					int componentIndex = unbindingTransform->getComponentIndex();
-					
-					// Get the molecule bonded at this site
-					if ( !mol->isBindingSiteBonded(componentIndex) )
-					{
-						// Site is not bonded, so this won't actually unbind anything
-						continue;
-					}
-					
-					Molecule * bondedMol = mol->getBondedMolecule(componentIndex);
-					if ( bondedMol == NULL )
-					{
-						// This shouldn't happen, but skip if it does
-						continue;
-					}
-					
-					// Check if bondedMol can reach mol through alternative paths
-					// (i.e., excluding the bond being broken)
-					if ( !canReachExcludingBond(mol, bondedMol, componentIndex) )
-					{
-						// Good: the molecules will be in different complexes after unbinding
-						continue;
-					}
-					else
-					{
-						// Bad: the molecules remain connected through other bonds
-						// This violates the product-side molecularity constraint
-						return false;
-					}
+				UnbindingTransform * unbindingTransform =
+					static_cast<UnbindingTransform *>( transform );
+
+				Mapping * mapping = mappingSets[0]->get(t);
+				if (mapping == NULL) {
+					continue;
+				}
+
+				// Get the molecule that will be unbound
+				Molecule * mol = mapping->getMolecule();
+				if (mol == NULL) {
+					continue;
+				}
+				int componentIndex = unbindingTransform->getComponentIndex();
+
+				// Get the molecule bonded at this site
+				if ( !mol->isBindingSiteBonded(componentIndex) )
+				{
+					// Site is not bonded, so this won't actually unbind anything
+					continue;
+				}
+
+				Molecule * bondedMol = mol->getBondedMolecule(componentIndex);
+				if ( bondedMol == NULL )
+				{
+					// This shouldn't happen, but skip if it does
+					continue;
+				}
+
+				int partnerIndex = mol->getBondedMoleculeBindingSiteIndex(componentIndex);
+				excludedBonds.push_back( std::make_pair(mol, componentIndex) );
+				excludedBonds.push_back( std::make_pair(bondedMol, partnerIndex) );
+				brokenPairs.push_back( std::make_pair(mol, bondedMol) );
+			}
+
+			// Second pass: with every deleted bond removed, each unbound pair must
+			// end up in different connected components. If any pair is still
+			// mutually reachable, the products do not actually separate, which
+			// violates the product-side molecularity constraint -> refuse to fire.
+			for ( unsigned int b = 0; b < brokenPairs.size(); ++b )
+			{
+				if ( canReachExcludingBonds( brokenPairs[b].first, brokenPairs[b].second, excludedBonds ) )
+				{
+					return false;
 				}
 			}
 		}

--- a/src/NFreactions/transformations/transformationSet.hh
+++ b/src/NFreactions/transformations/transformationSet.hh
@@ -5,6 +5,8 @@
 #include "../NFreactions.hh"
 #include <algorithm>
 #include <unordered_set>
+#include <vector>
+#include <utility>
 
 using namespace std;
 
@@ -340,15 +342,19 @@ namespace NFcore
 
 			/*!
 				Helper method to check if two molecules remain connected through alternative paths
-				when a specific bond is removed. This is used to enforce product-side molecularity
-				for unimolecular unbinding rules (Issue #48).
+				when a set of bonds is removed. This is used to enforce product-side molecularity
+				for unimolecular unbinding rules (Issue #48). The full set of bonds that the firing
+				rule will delete is excluded at once, so multi-bond ring-opening dissociations are
+				judged on the post-reaction graph rather than one bond in isolation.
 				@param mol1 The molecule containing the binding site
 				@param mol2 The bonded partner molecule
-				@param excludeComponentIndex The component index of the bond to exclude
+				@param excludedBonds The bonds to exclude, each recorded as both of its
+				       (molecule, component-index) half-edges
 				@return true if mol1 can be reached from mol2 through alternative paths, false otherwise
-				@author Fix for Issue #48
+				@author Fix for Issues #48 and #61
 			*/
-			bool canReachExcludingBond(Molecule *mol1, Molecule *mol2, int excludeComponentIndex);
+			bool canReachExcludingBonds(Molecule *mol1, Molecule *mol2,
+				const std::vector< std::pair<Molecule *, int> > &excludedBonds);
 
 			/*!	Remembers if the finalize function has been called	*/
 			bool finalized;

--- a/src/NFreactions/transformations/transformationSet.hh
+++ b/src/NFreactions/transformations/transformationSet.hh
@@ -4,6 +4,7 @@
 
 #include "../NFreactions.hh"
 #include <algorithm>
+#include <set>
 #include <unordered_set>
 #include <vector>
 #include <utility>
@@ -317,6 +318,15 @@ namespace NFcore
 			double getSymmetryFactor() const { return symmetryFactor; };
 			void   setSymmetryFactor(double val) { symmetryFactor = val; useSymmetryFactor = true; };
 
+			/*!
+				True if the rule does not transform reactant `reactantIndex` at all -- the
+				pattern is pure context.  Must be called after finalize(), which is where
+				this is decided; see the note there for why the transformation types alone
+				cannot answer it afterwards.
+				
+			*/
+			bool isPureContextReactant(unsigned int reactantIndex) const;
+
 			// To get the connected reactions for each transformation
 			bool checkConnection(ReactionClass * rxn);
 
@@ -380,6 +390,10 @@ namespace NFcore
 
 			/*!	A vector that holds the actual Transformation objects	*/
 			vector <Transformation *> *transformations;
+
+			/*!	Reactant indices the rule does not transform, recorded by finalize()
+			 *   before it appends a placeholder EMPTY transform to each of them	*/
+			set <unsigned int> pureContextReactants;
 
 			/*!	A vector that holds the addMolecule Transformations, because they are handled separately	*/
 			vector <AddMoleculeTransform *> addMoleculeTransformations;

--- a/src/NFtest/transformations/test_transformations.cpp
+++ b/src/NFtest/transformations/test_transformations.cpp
@@ -16,8 +16,34 @@ using namespace NFcore;
 class TestTransformationSet : public TransformationSet {
 public:
 	TestTransformationSet(vector<TemplateMolecule*> &reactants) : TransformationSet(reactants) {}
+	// Excludes the single bond anchored at m1's component excludeComp, recorded
+	// as both of its half-edges the way checkMolecularity() builds the set.
 	bool testCanReach(Molecule *m1, Molecule *m2, int excludeComp) {
-		return canReachExcludingBond(m1, m2, excludeComp);
+		vector< pair<Molecule *, int> > excludedBonds;
+		if (m1->isBindingSiteBonded(excludeComp)) {
+			Molecule *partner = m1->getBondedMolecule(excludeComp);
+			int partnerIndex = m1->getBondedMoleculeBindingSiteIndex(excludeComp);
+			excludedBonds.push_back(make_pair(m1, excludeComp));
+			excludedBonds.push_back(make_pair(partner, partnerIndex));
+		}
+		return canReachExcludingBonds(m1, m2, excludedBonds);
+	}
+
+	// Excludes an explicit set of bonds, each given as one (molecule, component)
+	// endpoint; the partner half-edge is derived here.
+	bool testCanReachExcluding(Molecule *m1, Molecule *m2,
+			const vector< pair<Molecule *, int> > &bonds) {
+		vector< pair<Molecule *, int> > excludedBonds;
+		for (unsigned int b = 0; b < bonds.size(); ++b) {
+			Molecule *mol = bonds[b].first;
+			int comp = bonds[b].second;
+			if (!mol->isBindingSiteBonded(comp)) continue;
+			Molecule *partner = mol->getBondedMolecule(comp);
+			int partnerIndex = mol->getBondedMoleculeBindingSiteIndex(comp);
+			excludedBonds.push_back(make_pair(mol, comp));
+			excludedBonds.push_back(make_pair(partner, partnerIndex));
+		}
+		return canReachExcludingBonds(m1, m2, excludedBonds);
 	}
 };
 
@@ -200,8 +226,8 @@ void NFtest_transformations::run()
 
 
 
-	// --- Testing canReachExcludingBond ---
-	cout << "  Testing canReachExcludingBond..." << endl;
+	// --- Testing canReachExcludingBonds ---
+	cout << "  Testing canReachExcludingBonds..." << endl;
 	vector<string> ringComps;
 	ringComps.push_back("s1");
 	ringComps.push_back("s2");
@@ -239,7 +265,7 @@ void NFtest_transformations::run()
 
 	// Test on the line m1 - m2. Exclude bond at m1's s1 (index 0).
 	if (testTS->testCanReach(m1, m2, 0) != false) {
-		throw runtime_error("canReachExcludingBond failed on line topology (should be false)");
+		throw runtime_error("canReachExcludingBonds failed on line topology (should be false)");
 	}
 
 	// Close the ring: m4(s2) - m1(s2)
@@ -247,7 +273,7 @@ void NFtest_transformations::run()
 
 	// Now m1, m2, m3, m4 are in a ring. Test excluding bond at m1's s1 (index 0).
 	if (testTS->testCanReach(m1, m2, 0) != true) {
-		throw runtime_error("canReachExcludingBond failed on ring topology (should be true)");
+		throw runtime_error("canReachExcludingBonds failed on ring topology (should be true)");
 	}
 
 	// Add another branch to test BFS robustness
@@ -255,13 +281,34 @@ void NFtest_transformations::run()
 	Molecule::bind(m3, 2, m5, 0); // m3(s3) - m5(s1)
 
 	if (testTS->testCanReach(m1, m2, 0) != true) {
-		throw runtime_error("canReachExcludingBond failed on ring topology with branch (should be true)");
+		throw runtime_error("canReachExcludingBonds failed on ring topology with branch (should be true)");
+	}
+
+	// A two-bond ring: the case a per-bond test cannot answer. m6 and m7 are
+	// bound to each other twice, so excluding either bond on its own leaves them
+	// connected through the other, while excluding both separates them. A rule
+	// that deletes both bonds at once is exactly this second question, and
+	// answering it one bond at a time is what used to block the dissociation.
+	Molecule *m6 = molRing->genDefaultMolecule();
+	Molecule *m7 = molRing->genDefaultMolecule();
+	Molecule::bind(m6, 0, m7, 0);
+	Molecule::bind(m6, 1, m7, 1);
+
+	if (testTS->testCanReach(m6, m7, 0) != true) {
+		throw runtime_error("canReachExcludingBonds: one bond of a two-bond ring should leave the pair connected");
+	}
+
+	vector< pair<Molecule *, int> > bothBonds;
+	bothBonds.push_back(make_pair(m6, 0));
+	bothBonds.push_back(make_pair(m6, 1));
+	if (testTS->testCanReachExcluding(m6, m7, bothBonds) != false) {
+		throw runtime_error("canReachExcludingBonds: excluding both bonds of a two-bond ring should separate the pair");
 	}
 
 	delete testTS;
 	delete tm1;
 
-	cout << "  canReachExcludingBond tests passed!" << endl;
+	cout << "  canReachExcludingBonds tests passed!" << endl;
 
 
 

--- a/test/context/context_symmetry.bngl
+++ b/test/context/context_symmetry.bngl
@@ -1,0 +1,219 @@
+# Counting a reactant pattern the rule does not transform (issue #87).
+#
+# BioNetGen gives such a pattern ONE reaction instance per matching complex,
+# however many molecules inside that complex match it: every embedding yields
+# the identical reaction -- same reactants, same products, same transformation
+# -- so there is only one. NFsim and RuleMonkey enumerate matches per molecule,
+# so they over-count any multi-subunit context and the rule fires that many
+# times too fast. BNG emits symmetry_factor="1" for all of these, so nothing in
+# the XML corrects it.
+#
+# Note the over-count is NOT a pattern-symmetry effect, which is why the last
+# two pairs below matter: Sub_scaffold's catalyst holds two *distinguishable*
+# copies and its pattern is a single molecule, so there is no symmetry anywhere,
+# and it is still counted twice.
+#
+# Every pool encodes the same intended per-substrate rate mu = kcat*E0, so all
+# of them must follow the same X0*exp(-mu*t):
+#
+#   Dim_sym / Dim_asym      Ez.Ez homodimer catalyst, constant rate    2x
+#   Ring_sym / Ring_asym    Tz.Tz.Tz homotrimer ring catalyst          3x
+#   Fn_sym / Fn_asym        homodimer catalyst, global function        2x
+#   Dor_sym / Dor_asym      homodimer catalyst, local function         2x
+#   Sub_subunit             ONE subunit pattern Ux(d!+) vs a homodimer 2x
+#   Sub_scaffold            Vx(d) vs a scaffold holding two distinct   2x
+#   Sub_trimer              ONE subunit pattern Tx(a!+) vs a homotrimer 3x
+#
+# Sub_trimer is the one shape that separates per-complex counting from
+# `embeddings / |Aut(pattern)|`, the formula issue #87 implicitly suggests, at a
+# factor of THREE. Read the two together: Ring_sym's pattern is the whole ring,
+# so its 3 embeddings are divided by |Aut(pattern)|=3 and both rules answer 1 --
+# which is why the ring alone cannot tell them apart. Sub_trimer's pattern is a
+# single molecule with no automorphism at all, so the formula answers 3 and BNG
+# answers 1. Sub_subunit and Sub_scaffold make the same point at 2x; this makes
+# it the shape where a fix hardcoded to a factor of two would also be caught.
+#
+# In each pair the two rules differ only in whether the catalyst complex's
+# halves (or thirds) are the same molecule type. The catalyst is never
+# transformed, so the pairs are a direct control: a gap between them is the
+# defect, whatever the rate law.
+#
+# Mm_sym / Mm_asym is the Michaelis-Menten pair. It has no closed form here, so
+# the pairing is its only oracle. Note the enzyme is the axis MM is nearly
+# linear in, so this pair sees the 2x but cannot say whether the correction sits
+# on the count or on the propensity; symmetry_factor_mm_saturated.bngl is the
+# fixture that probes placement, on the substrate axis.
+#
+# Bind_sym / Bind_asym is the guard in the other direction. Its catalyst dimer
+# IS a reaction center -- one half of it binds -- so its two halves are two
+# genuinely distinct reactions and the 2x is correct. BNG says so in the
+# generated network: this rule gets `2*kb` where the heterodimer control gets
+# `kb`. The factor lives THERE and not in symmetry_factor, which is "1" for this
+# rule as it is for every other rule in this file -- so there is nothing for
+# NFsim to divide out, and per-molecule counting is what reproduces the 2x.
+# (An earlier version of this note said BNG emits symmetry_factor="0.5" here and
+# that NFsim divides it out. Both halves were wrong; the XML beside this file
+# has always read "1". The conclusion the note drew is unaffected -- this pair
+# must not be corrected a second time -- but do not reason from the mechanism it
+# named.) This pair is not incidental: NFsim marks the second partner of a
+# binding with an EMPTY transform, the same type finalize() uses for the
+# placeholder on an untransformed reactant, so "no real transformation" read off
+# the transformation types alone misclassifies exactly this rule.
+#
+# Bind_sym is also the case that bounds how the rule may be STATED. It is a
+# single distinct (reactant species tuple -> product species tuple) -- both
+# embeddings give the identical product, because the dimer is symmetric -- and
+# BNG still emits 2*kb. So "BNG deduplicates identical reactions during network
+# expansion" over-collapses: the discriminator is not whether the products
+# coincide, it is whether the rule TRANSFORMS the pattern. That is what
+# TransformationSet::isPureContextReactant() keys on.
+
+begin model
+begin parameters
+  X0    4000
+  E0    10
+  kcat  2.5e-5      # mu = kcat*E0 = 2.5e-4; at t=2000, mu*t = 0.5
+
+  # Michaelis-Menten pair: X0/Km = 0.4, above the linear regime
+  Km     1.0e4
+  kcatM  0.35
+
+  # Binding pair: B0 free monomers against D0 catalyst dimers
+  B0    500
+  D0    1000
+  kb    2.5e-7      # kb*D0*t = 0.5 at t=2000
+end parameters
+
+begin molecule types
+  Src()
+  DimS(s~0~1)
+  DimA(s~0~1)
+  RingS(s~0~1)
+  RingA(s~0~1)
+  FnS(s~0~1)
+  FnA(s~0~1)
+  DorS(s~0~1)
+  DorA(s~0~1)
+  MmS(s~0~1)
+  MmA(s~0~1)
+  SubU(s~0~1)
+  SubV(s~0~1)
+  SubT(s~0~1)
+  BndS(b)
+  BndA(b)
+  # catalysts, one distinct set per rule so the rules cannot cross-talk
+  Ez(d)
+  Fz(d)
+  Gz(d)
+  Tz(a,b)
+  Pz(a,b)
+  Qz(a,b)
+  Rz(a,b)
+  Nz(d)
+  Uz(d)
+  Vz(d)
+  Wz(d)
+  Yz(d)
+  Zz(d)
+  Cz(d)
+  Iz(d)
+  Jz(d)
+  Hz(d,c)
+  Kz(d,c)
+  Lz(d,c)
+  Ux(d)
+  Vx(d,t)
+  Vs(p,q)
+  Tx(a,b)
+end molecule types
+
+begin seed species
+  Src()        1
+  DimS(s~0)    X0
+  DimA(s~0)    X0
+  RingS(s~0)   X0
+  RingA(s~0)   X0
+  FnS(s~0)     X0
+  FnA(s~0)     X0
+  DorS(s~0)    X0
+  DorA(s~0)    X0
+  MmS(s~0)     X0
+  MmA(s~0)     X0
+  SubU(s~0)    X0
+  SubV(s~0)    X0
+  SubT(s~0)    X0
+  BndS(b)      B0
+  BndA(b)      B0
+
+  Ez(d!1).Ez(d!1)                     E0
+  Fz(d!1).Gz(d!1)                     E0
+  Tz(a!1,b!3).Tz(a!2,b!1).Tz(a!3,b!2) E0
+  Pz(a!1,b!3).Qz(a!2,b!1).Rz(a!3,b!2) E0
+  Nz(d!1).Nz(d!1)                     E0
+  Uz(d!1).Vz(d!1)                     E0
+  Wz(d!1).Wz(d!1)                     E0
+  Yz(d!1).Zz(d!1)                     E0
+  Cz(d!1).Cz(d!1)                     E0
+  Iz(d!1).Jz(d!1)                     E0
+  Hz(d!1,c).Hz(d!1,c)                 D0
+  Kz(d!1,c).Lz(d!1,c)                 D0
+  # two Ux per complex, related by symmetry
+  Ux(d!1).Ux(d!1)                     E0
+  # two Vx per complex at DISTINGUISHABLE scaffold positions -- no symmetry at all
+  Vx(d,t!1).Vs(p!1,q!2).Vx(d,t!2)     E0
+  # THREE Tx per complex against a single-molecule pattern: embeddings=3,
+  # |Aut(pattern)|=1, so this is where the two candidate rules differ by 3x
+  Tx(a!1,b!3).Tx(a!2,b!1).Tx(a!3,b!2) E0
+end seed species
+
+begin observables
+  Molecules Obs_Src    Src()
+  Molecules Cnt_Wz     Wz()
+  Molecules Cnt_Zz     Zz()
+  Molecules Dim_sym    DimS(s~0)
+  Molecules Dim_asym   DimA(s~0)
+  Molecules Ring_sym   RingS(s~0)
+  Molecules Ring_asym  RingA(s~0)
+  Molecules Fn_sym     FnS(s~0)
+  Molecules Fn_asym    FnA(s~0)
+  Molecules Dor_sym    DorS(s~0)
+  Molecules Dor_asym   DorA(s~0)
+  Molecules Mm_sym     MmS(s~0)
+  Molecules Mm_asym    MmA(s~0)
+  Molecules Bind_sym   BndS(b)
+  Molecules Bind_asym  BndA(b)
+  Molecules Sub_subunit   SubU(s~0)
+  Molecules Sub_scaffold  SubV(s~0)
+  Molecules Sub_trimer    SubT(s~0)
+end observables
+
+begin functions
+  gfn()    = kcat*Obs_Src
+  locs(x)  = kcat*Obs_Src + 0*Cnt_Wz(x)
+  loca(x)  = kcat*Obs_Src + 0*Cnt_Zz(x)
+end functions
+
+begin reaction rules
+  R_dim_sym:   DimS(s~0)  + Ez(d!1).Ez(d!1)                     -> DimS(s~1)  + Ez(d!1).Ez(d!1)                     kcat
+  R_dim_asym:  DimA(s~0)  + Fz(d!1).Gz(d!1)                     -> DimA(s~1)  + Fz(d!1).Gz(d!1)                     kcat
+  R_ring_sym:  RingS(s~0) + Tz(a!1,b!3).Tz(a!2,b!1).Tz(a!3,b!2) -> RingS(s~1) + Tz(a!1,b!3).Tz(a!2,b!1).Tz(a!3,b!2) kcat
+  R_ring_asym: RingA(s~0) + Pz(a!1,b!3).Qz(a!2,b!1).Rz(a!3,b!2) -> RingA(s~1) + Pz(a!1,b!3).Qz(a!2,b!1).Rz(a!3,b!2) kcat
+  R_fn_sym:    FnS(s~0)   + Nz(d!1).Nz(d!1)                     -> FnS(s~1)   + Nz(d!1).Nz(d!1)                     gfn()
+  R_fn_asym:   FnA(s~0)   + Uz(d!1).Vz(d!1)                     -> FnA(s~1)   + Uz(d!1).Vz(d!1)                     gfn()
+  R_dor_sym:   DorS(s~0)  + Wz(d!1)%x.Wz(d!1)                   -> DorS(s~1)  + Wz(d!1)%x.Wz(d!1)                   locs(x)
+  R_dor_asym:  DorA(s~0)  + Yz(d!1).Zz(d!1)%x                   -> DorA(s~1)  + Yz(d!1).Zz(d!1)%x                   loca(x)
+  R_mm_sym:    MmS(s~0)   + Cz(d!1).Cz(d!1)                     -> MmS(s~1)   + Cz(d!1).Cz(d!1)                     MM(kcatM,Km)
+  R_mm_asym:   MmA(s~0)   + Iz(d!1).Jz(d!1)                     -> MmA(s~1)   + Iz(d!1).Jz(d!1)                     MM(kcatM,Km)
+  # Single-molecule context patterns. No pattern symmetry, yet two molecules per
+  # complex match, so a fix keyed on the pattern's own symmetry misses both.
+  R_subunit:   SubU(s~0)  + Ux(d!+)                             -> SubU(s~1)  + Ux(d!+)                             kcat
+  R_scaffold:  SubV(s~0)  + Vx(d)                               -> SubV(s~1)  + Vx(d)                               kcat
+  R_trimer:    SubT(s~0)  + Tx(a!+)                             -> SubT(s~1)  + Tx(a!+)                             kcat
+  R_bind_sym:  BndS(b)    + Hz(d!1,c).Hz(d!1,c)                 -> BndS(b!2).Hz(d!1,c!2).Hz(d!1,c)                  kb
+  R_bind_asym: BndA(b)    + Kz(d!1,c).Lz(d!1,c)                 -> BndA(b!2).Kz(d!1,c!2).Lz(d!1,c)                  kb
+end reaction rules
+end model
+
+begin actions
+  writeXML({overwrite=>1})
+end actions

--- a/test/context/context_symmetry.xml
+++ b/test/context/context_symmetry.xml
@@ -1,0 +1,2117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by BioNetGen 2.9.3  -->
+<sbml xmlns="http://www.sbml.org/sbml/level3" level="3" version="1">
+  <model id="context_symmetry">
+    <ListOfParameters>
+      <Parameter id="X0" type="Constant" value="4000" expr="4000"/>
+      <Parameter id="E0" type="Constant" value="10" expr="10"/>
+      <Parameter id="kcat" type="Constant" value="2.5e-5" expr="2.5e-5"/>
+      <Parameter id="Km" type="Constant" value="10000" expr="1.0e4"/>
+      <Parameter id="kcatM" type="Constant" value="0.35" expr="0.35"/>
+      <Parameter id="B0" type="Constant" value="500" expr="500"/>
+      <Parameter id="D0" type="Constant" value="1000" expr="1000"/>
+      <Parameter id="kb" type="Constant" value="2.5e-7" expr="2.5e-7"/>
+    </ListOfParameters>
+    <ListOfMoleculeTypes>
+      <MoleculeType id="BndA">
+        <ListOfComponentTypes>
+          <ComponentType id="b"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="BndS">
+        <ListOfComponentTypes>
+          <ComponentType id="b"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Cz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="DimA">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="DimS">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="DorA">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="DorS">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Ez">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="FnA">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="FnS">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Fz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Gz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Hz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+          <ComponentType id="c"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Iz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Jz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Kz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+          <ComponentType id="c"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Lz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+          <ComponentType id="c"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="MmA">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="MmS">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Nz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Pz">
+        <ListOfComponentTypes>
+          <ComponentType id="a"/>
+          <ComponentType id="b"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Qz">
+        <ListOfComponentTypes>
+          <ComponentType id="a"/>
+          <ComponentType id="b"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="RingA">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="RingS">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Rz">
+        <ListOfComponentTypes>
+          <ComponentType id="a"/>
+          <ComponentType id="b"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Src"/>
+      <MoleculeType id="SubT">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="SubU">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="SubV">
+        <ListOfComponentTypes>
+          <ComponentType id="s">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Tx">
+        <ListOfComponentTypes>
+          <ComponentType id="a"/>
+          <ComponentType id="b"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Tz">
+        <ListOfComponentTypes>
+          <ComponentType id="a"/>
+          <ComponentType id="b"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Ux">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Uz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Vs">
+        <ListOfComponentTypes>
+          <ComponentType id="p"/>
+          <ComponentType id="q"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Vx">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+          <ComponentType id="t"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Vz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Wz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Yz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Zz">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+    </ListOfMoleculeTypes>
+    <ListOfCompartments>
+    </ListOfCompartments>
+    <ListOfSpecies>
+      <Species id="S1"  concentration="1" name="Src()">
+        <ListOfMolecules>
+          <Molecule id="S1_M1" name="Src"/>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S2"  concentration="X0" name="DimS(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S2_M1" name="DimS">
+            <ListOfComponents>
+              <Component id="S2_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S3"  concentration="X0" name="DimA(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S3_M1" name="DimA">
+            <ListOfComponents>
+              <Component id="S3_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S4"  concentration="X0" name="RingS(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S4_M1" name="RingS">
+            <ListOfComponents>
+              <Component id="S4_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S5"  concentration="X0" name="RingA(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S5_M1" name="RingA">
+            <ListOfComponents>
+              <Component id="S5_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S6"  concentration="X0" name="FnS(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S6_M1" name="FnS">
+            <ListOfComponents>
+              <Component id="S6_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S7"  concentration="X0" name="FnA(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S7_M1" name="FnA">
+            <ListOfComponents>
+              <Component id="S7_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S8"  concentration="X0" name="DorS(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S8_M1" name="DorS">
+            <ListOfComponents>
+              <Component id="S8_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S9"  concentration="X0" name="DorA(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S9_M1" name="DorA">
+            <ListOfComponents>
+              <Component id="S9_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S10"  concentration="X0" name="MmS(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S10_M1" name="MmS">
+            <ListOfComponents>
+              <Component id="S10_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S11"  concentration="X0" name="MmA(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S11_M1" name="MmA">
+            <ListOfComponents>
+              <Component id="S11_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S12"  concentration="X0" name="SubU(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S12_M1" name="SubU">
+            <ListOfComponents>
+              <Component id="S12_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S13"  concentration="X0" name="SubV(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S13_M1" name="SubV">
+            <ListOfComponents>
+              <Component id="S13_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S14"  concentration="X0" name="SubT(s~0)">
+        <ListOfMolecules>
+          <Molecule id="S14_M1" name="SubT">
+            <ListOfComponents>
+              <Component id="S14_M1_C1" name="s" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S15"  concentration="B0" name="BndS(b)">
+        <ListOfMolecules>
+          <Molecule id="S15_M1" name="BndS">
+            <ListOfComponents>
+              <Component id="S15_M1_C1" name="b" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S16"  concentration="B0" name="BndA(b)">
+        <ListOfMolecules>
+          <Molecule id="S16_M1" name="BndA">
+            <ListOfComponents>
+              <Component id="S16_M1_C1" name="b" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S17"  concentration="E0" name="Ez(d!1).Ez(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S17_M1" name="Ez">
+            <ListOfComponents>
+              <Component id="S17_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S17_M2" name="Ez">
+            <ListOfComponents>
+              <Component id="S17_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S17_B1" site1="S17_M1_C1" site2="S17_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S18"  concentration="E0" name="Fz(d!1).Gz(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S18_M1" name="Fz">
+            <ListOfComponents>
+              <Component id="S18_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S18_M2" name="Gz">
+            <ListOfComponents>
+              <Component id="S18_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S18_B1" site1="S18_M1_C1" site2="S18_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S19"  concentration="E0" name="Tz(a!1,b!2).Tz(a!3,b!1).Tz(a!2,b!3)">
+        <ListOfMolecules>
+          <Molecule id="S19_M1" name="Tz">
+            <ListOfComponents>
+              <Component id="S19_M1_C1" name="a" numberOfBonds="1"/>
+              <Component id="S19_M1_C2" name="b" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S19_M2" name="Tz">
+            <ListOfComponents>
+              <Component id="S19_M2_C1" name="a" numberOfBonds="1"/>
+              <Component id="S19_M2_C2" name="b" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S19_M3" name="Tz">
+            <ListOfComponents>
+              <Component id="S19_M3_C1" name="a" numberOfBonds="1"/>
+              <Component id="S19_M3_C2" name="b" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S19_B1" site1="S19_M1_C1" site2="S19_M2_C2"/>
+          <Bond id="S19_B2" site1="S19_M1_C2" site2="S19_M3_C1"/>
+          <Bond id="S19_B3" site1="S19_M2_C1" site2="S19_M3_C2"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S20"  concentration="E0" name="Pz(a!1,b!2).Qz(a!3,b!1).Rz(a!2,b!3)">
+        <ListOfMolecules>
+          <Molecule id="S20_M1" name="Pz">
+            <ListOfComponents>
+              <Component id="S20_M1_C1" name="a" numberOfBonds="1"/>
+              <Component id="S20_M1_C2" name="b" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S20_M2" name="Qz">
+            <ListOfComponents>
+              <Component id="S20_M2_C1" name="a" numberOfBonds="1"/>
+              <Component id="S20_M2_C2" name="b" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S20_M3" name="Rz">
+            <ListOfComponents>
+              <Component id="S20_M3_C1" name="a" numberOfBonds="1"/>
+              <Component id="S20_M3_C2" name="b" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S20_B1" site1="S20_M1_C1" site2="S20_M2_C2"/>
+          <Bond id="S20_B2" site1="S20_M1_C2" site2="S20_M3_C1"/>
+          <Bond id="S20_B3" site1="S20_M2_C1" site2="S20_M3_C2"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S21"  concentration="E0" name="Nz(d!1).Nz(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S21_M1" name="Nz">
+            <ListOfComponents>
+              <Component id="S21_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S21_M2" name="Nz">
+            <ListOfComponents>
+              <Component id="S21_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S21_B1" site1="S21_M1_C1" site2="S21_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S22"  concentration="E0" name="Uz(d!1).Vz(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S22_M1" name="Uz">
+            <ListOfComponents>
+              <Component id="S22_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S22_M2" name="Vz">
+            <ListOfComponents>
+              <Component id="S22_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S22_B1" site1="S22_M1_C1" site2="S22_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S23"  concentration="E0" name="Wz(d!1).Wz(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S23_M1" name="Wz">
+            <ListOfComponents>
+              <Component id="S23_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S23_M2" name="Wz">
+            <ListOfComponents>
+              <Component id="S23_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S23_B1" site1="S23_M1_C1" site2="S23_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S24"  concentration="E0" name="Yz(d!1).Zz(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S24_M1" name="Yz">
+            <ListOfComponents>
+              <Component id="S24_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S24_M2" name="Zz">
+            <ListOfComponents>
+              <Component id="S24_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S24_B1" site1="S24_M1_C1" site2="S24_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S25"  concentration="E0" name="Cz(d!1).Cz(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S25_M1" name="Cz">
+            <ListOfComponents>
+              <Component id="S25_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S25_M2" name="Cz">
+            <ListOfComponents>
+              <Component id="S25_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S25_B1" site1="S25_M1_C1" site2="S25_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S26"  concentration="E0" name="Iz(d!1).Jz(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S26_M1" name="Iz">
+            <ListOfComponents>
+              <Component id="S26_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S26_M2" name="Jz">
+            <ListOfComponents>
+              <Component id="S26_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S26_B1" site1="S26_M1_C1" site2="S26_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S27"  concentration="D0" name="Hz(c,d!1).Hz(c,d!1)">
+        <ListOfMolecules>
+          <Molecule id="S27_M1" name="Hz">
+            <ListOfComponents>
+              <Component id="S27_M1_C1" name="c" numberOfBonds="0"/>
+              <Component id="S27_M1_C2" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S27_M2" name="Hz">
+            <ListOfComponents>
+              <Component id="S27_M2_C1" name="c" numberOfBonds="0"/>
+              <Component id="S27_M2_C2" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S27_B1" site1="S27_M1_C2" site2="S27_M2_C2"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S28"  concentration="D0" name="Kz(c,d!1).Lz(c,d!1)">
+        <ListOfMolecules>
+          <Molecule id="S28_M1" name="Kz">
+            <ListOfComponents>
+              <Component id="S28_M1_C1" name="c" numberOfBonds="0"/>
+              <Component id="S28_M1_C2" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S28_M2" name="Lz">
+            <ListOfComponents>
+              <Component id="S28_M2_C1" name="c" numberOfBonds="0"/>
+              <Component id="S28_M2_C2" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S28_B1" site1="S28_M1_C2" site2="S28_M2_C2"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S29"  concentration="E0" name="Ux(d!1).Ux(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S29_M1" name="Ux">
+            <ListOfComponents>
+              <Component id="S29_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S29_M2" name="Ux">
+            <ListOfComponents>
+              <Component id="S29_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S29_B1" site1="S29_M1_C1" site2="S29_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S30"  concentration="E0" name="Vs(p!1,q!2).Vx(d,t!1).Vx(d,t!2)">
+        <ListOfMolecules>
+          <Molecule id="S30_M1" name="Vs">
+            <ListOfComponents>
+              <Component id="S30_M1_C1" name="p" numberOfBonds="1"/>
+              <Component id="S30_M1_C2" name="q" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S30_M2" name="Vx">
+            <ListOfComponents>
+              <Component id="S30_M2_C1" name="d" numberOfBonds="0"/>
+              <Component id="S30_M2_C2" name="t" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S30_M3" name="Vx">
+            <ListOfComponents>
+              <Component id="S30_M3_C1" name="d" numberOfBonds="0"/>
+              <Component id="S30_M3_C2" name="t" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S30_B1" site1="S30_M1_C1" site2="S30_M2_C2"/>
+          <Bond id="S30_B2" site1="S30_M1_C2" site2="S30_M3_C2"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S31"  concentration="E0" name="Tx(a!1,b!2).Tx(a!3,b!1).Tx(a!2,b!3)">
+        <ListOfMolecules>
+          <Molecule id="S31_M1" name="Tx">
+            <ListOfComponents>
+              <Component id="S31_M1_C1" name="a" numberOfBonds="1"/>
+              <Component id="S31_M1_C2" name="b" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S31_M2" name="Tx">
+            <ListOfComponents>
+              <Component id="S31_M2_C1" name="a" numberOfBonds="1"/>
+              <Component id="S31_M2_C2" name="b" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S31_M3" name="Tx">
+            <ListOfComponents>
+              <Component id="S31_M3_C1" name="a" numberOfBonds="1"/>
+              <Component id="S31_M3_C2" name="b" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S31_B1" site1="S31_M1_C1" site2="S31_M2_C2"/>
+          <Bond id="S31_B2" site1="S31_M1_C2" site2="S31_M3_C1"/>
+          <Bond id="S31_B3" site1="S31_M2_C1" site2="S31_M3_C2"/>
+        </ListOfBonds>
+      </Species>
+    </ListOfSpecies>
+    <ListOfReactionRules>
+      <ReactionRule id="RR1" name="R_dim_sym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR1_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_RP1_M1" name="DimS">
+                <ListOfComponents>
+                  <Component id="RR1_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR1_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR1_RP2_M1" name="Ez">
+                <ListOfComponents>
+                  <Component id="RR1_RP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR1_RP2_M2" name="Ez">
+                <ListOfComponents>
+                  <Component id="RR1_RP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR1_RP2_B1" site1="RR1_RP2_M1_C1" site2="RR1_RP2_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR1_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_PP1_M1" name="DimS">
+                <ListOfComponents>
+                  <Component id="RR1_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR1_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR1_PP2_M1" name="Ez">
+                <ListOfComponents>
+                  <Component id="RR1_PP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR1_PP2_M2" name="Ez">
+                <ListOfComponents>
+                  <Component id="RR1_PP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR1_PP2_B1" site1="RR1_PP2_M1_C1" site2="RR1_PP2_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR1_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR1_RP1_M1" targetID="RR1_PP1_M1"/>
+          <MapItem sourceID="RR1_RP1_M1_C1" targetID="RR1_PP1_M1_C1"/>
+          <MapItem sourceID="RR1_RP2_M1" targetID="RR1_PP2_M1"/>
+          <MapItem sourceID="RR1_RP2_M1_C1" targetID="RR1_PP2_M1_C1"/>
+          <MapItem sourceID="RR1_RP2_M2" targetID="RR1_PP2_M2"/>
+          <MapItem sourceID="RR1_RP2_M2_C1" targetID="RR1_PP2_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR1_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR2" name="R_dim_asym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR2_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR2_RP1_M1" name="DimA">
+                <ListOfComponents>
+                  <Component id="RR2_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR2_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR2_RP2_M1" name="Fz">
+                <ListOfComponents>
+                  <Component id="RR2_RP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR2_RP2_M2" name="Gz">
+                <ListOfComponents>
+                  <Component id="RR2_RP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR2_RP2_B1" site1="RR2_RP2_M1_C1" site2="RR2_RP2_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR2_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR2_PP1_M1" name="DimA">
+                <ListOfComponents>
+                  <Component id="RR2_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR2_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR2_PP2_M1" name="Fz">
+                <ListOfComponents>
+                  <Component id="RR2_PP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR2_PP2_M2" name="Gz">
+                <ListOfComponents>
+                  <Component id="RR2_PP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR2_PP2_B1" site1="RR2_PP2_M1_C1" site2="RR2_PP2_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR2_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR2_RP1_M1" targetID="RR2_PP1_M1"/>
+          <MapItem sourceID="RR2_RP1_M1_C1" targetID="RR2_PP1_M1_C1"/>
+          <MapItem sourceID="RR2_RP2_M1" targetID="RR2_PP2_M1"/>
+          <MapItem sourceID="RR2_RP2_M1_C1" targetID="RR2_PP2_M1_C1"/>
+          <MapItem sourceID="RR2_RP2_M2" targetID="RR2_PP2_M2"/>
+          <MapItem sourceID="RR2_RP2_M2_C1" targetID="RR2_PP2_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR2_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR3" name="R_ring_sym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR3_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR3_RP1_M1" name="RingS">
+                <ListOfComponents>
+                  <Component id="RR3_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR3_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR3_RP2_M1" name="Tz">
+                <ListOfComponents>
+                  <Component id="RR3_RP2_M1_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR3_RP2_M1_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR3_RP2_M2" name="Tz">
+                <ListOfComponents>
+                  <Component id="RR3_RP2_M2_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR3_RP2_M2_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR3_RP2_M3" name="Tz">
+                <ListOfComponents>
+                  <Component id="RR3_RP2_M3_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR3_RP2_M3_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR3_RP2_B1" site1="RR3_RP2_M1_C1" site2="RR3_RP2_M2_C2"/>
+              <Bond id="RR3_RP2_B2" site1="RR3_RP2_M1_C2" site2="RR3_RP2_M3_C1"/>
+              <Bond id="RR3_RP2_B3" site1="RR3_RP2_M2_C1" site2="RR3_RP2_M3_C2"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR3_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR3_PP1_M1" name="RingS">
+                <ListOfComponents>
+                  <Component id="RR3_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR3_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR3_PP2_M1" name="Tz">
+                <ListOfComponents>
+                  <Component id="RR3_PP2_M1_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR3_PP2_M1_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR3_PP2_M2" name="Tz">
+                <ListOfComponents>
+                  <Component id="RR3_PP2_M2_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR3_PP2_M2_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR3_PP2_M3" name="Tz">
+                <ListOfComponents>
+                  <Component id="RR3_PP2_M3_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR3_PP2_M3_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR3_PP2_B1" site1="RR3_PP2_M1_C1" site2="RR3_PP2_M2_C2"/>
+              <Bond id="RR3_PP2_B2" site1="RR3_PP2_M1_C2" site2="RR3_PP2_M3_C1"/>
+              <Bond id="RR3_PP2_B3" site1="RR3_PP2_M2_C1" site2="RR3_PP2_M3_C2"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR3_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR3_RP1_M1" targetID="RR3_PP1_M1"/>
+          <MapItem sourceID="RR3_RP1_M1_C1" targetID="RR3_PP1_M1_C1"/>
+          <MapItem sourceID="RR3_RP2_M1" targetID="RR3_PP2_M1"/>
+          <MapItem sourceID="RR3_RP2_M1_C1" targetID="RR3_PP2_M1_C1"/>
+          <MapItem sourceID="RR3_RP2_M1_C2" targetID="RR3_PP2_M1_C2"/>
+          <MapItem sourceID="RR3_RP2_M2" targetID="RR3_PP2_M2"/>
+          <MapItem sourceID="RR3_RP2_M2_C1" targetID="RR3_PP2_M2_C1"/>
+          <MapItem sourceID="RR3_RP2_M2_C2" targetID="RR3_PP2_M2_C2"/>
+          <MapItem sourceID="RR3_RP2_M3" targetID="RR3_PP2_M3"/>
+          <MapItem sourceID="RR3_RP2_M3_C1" targetID="RR3_PP2_M3_C1"/>
+          <MapItem sourceID="RR3_RP2_M3_C2" targetID="RR3_PP2_M3_C2"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR3_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR4" name="R_ring_asym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR4_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR4_RP1_M1" name="RingA">
+                <ListOfComponents>
+                  <Component id="RR4_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR4_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR4_RP2_M1" name="Pz">
+                <ListOfComponents>
+                  <Component id="RR4_RP2_M1_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR4_RP2_M1_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR4_RP2_M2" name="Qz">
+                <ListOfComponents>
+                  <Component id="RR4_RP2_M2_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR4_RP2_M2_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR4_RP2_M3" name="Rz">
+                <ListOfComponents>
+                  <Component id="RR4_RP2_M3_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR4_RP2_M3_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR4_RP2_B1" site1="RR4_RP2_M1_C1" site2="RR4_RP2_M2_C2"/>
+              <Bond id="RR4_RP2_B2" site1="RR4_RP2_M1_C2" site2="RR4_RP2_M3_C1"/>
+              <Bond id="RR4_RP2_B3" site1="RR4_RP2_M2_C1" site2="RR4_RP2_M3_C2"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR4_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR4_PP1_M1" name="RingA">
+                <ListOfComponents>
+                  <Component id="RR4_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR4_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR4_PP2_M1" name="Pz">
+                <ListOfComponents>
+                  <Component id="RR4_PP2_M1_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR4_PP2_M1_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR4_PP2_M2" name="Qz">
+                <ListOfComponents>
+                  <Component id="RR4_PP2_M2_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR4_PP2_M2_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR4_PP2_M3" name="Rz">
+                <ListOfComponents>
+                  <Component id="RR4_PP2_M3_C1" name="a" numberOfBonds="1"/>
+                  <Component id="RR4_PP2_M3_C2" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR4_PP2_B1" site1="RR4_PP2_M1_C1" site2="RR4_PP2_M2_C2"/>
+              <Bond id="RR4_PP2_B2" site1="RR4_PP2_M1_C2" site2="RR4_PP2_M3_C1"/>
+              <Bond id="RR4_PP2_B3" site1="RR4_PP2_M2_C1" site2="RR4_PP2_M3_C2"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR4_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR4_RP1_M1" targetID="RR4_PP1_M1"/>
+          <MapItem sourceID="RR4_RP1_M1_C1" targetID="RR4_PP1_M1_C1"/>
+          <MapItem sourceID="RR4_RP2_M1" targetID="RR4_PP2_M1"/>
+          <MapItem sourceID="RR4_RP2_M1_C1" targetID="RR4_PP2_M1_C1"/>
+          <MapItem sourceID="RR4_RP2_M1_C2" targetID="RR4_PP2_M1_C2"/>
+          <MapItem sourceID="RR4_RP2_M2" targetID="RR4_PP2_M2"/>
+          <MapItem sourceID="RR4_RP2_M2_C1" targetID="RR4_PP2_M2_C1"/>
+          <MapItem sourceID="RR4_RP2_M2_C2" targetID="RR4_PP2_M2_C2"/>
+          <MapItem sourceID="RR4_RP2_M3" targetID="RR4_PP2_M3"/>
+          <MapItem sourceID="RR4_RP2_M3_C1" targetID="RR4_PP2_M3_C1"/>
+          <MapItem sourceID="RR4_RP2_M3_C2" targetID="RR4_PP2_M3_C2"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR4_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR5" name="R_fn_sym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR5_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR5_RP1_M1" name="FnS">
+                <ListOfComponents>
+                  <Component id="RR5_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR5_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR5_RP2_M1" name="Nz">
+                <ListOfComponents>
+                  <Component id="RR5_RP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR5_RP2_M2" name="Nz">
+                <ListOfComponents>
+                  <Component id="RR5_RP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR5_RP2_B1" site1="RR5_RP2_M1_C1" site2="RR5_RP2_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR5_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR5_PP1_M1" name="FnS">
+                <ListOfComponents>
+                  <Component id="RR5_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR5_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR5_PP2_M1" name="Nz">
+                <ListOfComponents>
+                  <Component id="RR5_PP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR5_PP2_M2" name="Nz">
+                <ListOfComponents>
+                  <Component id="RR5_PP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR5_PP2_B1" site1="RR5_PP2_M1_C1" site2="RR5_PP2_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR5_RateLaw" type="Function" name="gfn" totalrate="0">
+          <ListOfArguments>
+          </ListOfArguments>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR5_RP1_M1" targetID="RR5_PP1_M1"/>
+          <MapItem sourceID="RR5_RP1_M1_C1" targetID="RR5_PP1_M1_C1"/>
+          <MapItem sourceID="RR5_RP2_M1" targetID="RR5_PP2_M1"/>
+          <MapItem sourceID="RR5_RP2_M1_C1" targetID="RR5_PP2_M1_C1"/>
+          <MapItem sourceID="RR5_RP2_M2" targetID="RR5_PP2_M2"/>
+          <MapItem sourceID="RR5_RP2_M2_C1" targetID="RR5_PP2_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR5_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR6" name="R_fn_asym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR6_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR6_RP1_M1" name="FnA">
+                <ListOfComponents>
+                  <Component id="RR6_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR6_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR6_RP2_M1" name="Uz">
+                <ListOfComponents>
+                  <Component id="RR6_RP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR6_RP2_M2" name="Vz">
+                <ListOfComponents>
+                  <Component id="RR6_RP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR6_RP2_B1" site1="RR6_RP2_M1_C1" site2="RR6_RP2_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR6_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR6_PP1_M1" name="FnA">
+                <ListOfComponents>
+                  <Component id="RR6_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR6_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR6_PP2_M1" name="Uz">
+                <ListOfComponents>
+                  <Component id="RR6_PP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR6_PP2_M2" name="Vz">
+                <ListOfComponents>
+                  <Component id="RR6_PP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR6_PP2_B1" site1="RR6_PP2_M1_C1" site2="RR6_PP2_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR6_RateLaw" type="Function" name="gfn" totalrate="0">
+          <ListOfArguments>
+          </ListOfArguments>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR6_RP1_M1" targetID="RR6_PP1_M1"/>
+          <MapItem sourceID="RR6_RP1_M1_C1" targetID="RR6_PP1_M1_C1"/>
+          <MapItem sourceID="RR6_RP2_M1" targetID="RR6_PP2_M1"/>
+          <MapItem sourceID="RR6_RP2_M1_C1" targetID="RR6_PP2_M1_C1"/>
+          <MapItem sourceID="RR6_RP2_M2" targetID="RR6_PP2_M2"/>
+          <MapItem sourceID="RR6_RP2_M2_C1" targetID="RR6_PP2_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR6_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR7" name="R_dor_sym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR7_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR7_RP1_M1" name="DorS">
+                <ListOfComponents>
+                  <Component id="RR7_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR7_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR7_RP2_M1" name="Wz" label="x">
+                <ListOfComponents>
+                  <Component id="RR7_RP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR7_RP2_M2" name="Wz">
+                <ListOfComponents>
+                  <Component id="RR7_RP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR7_RP2_B1" site1="RR7_RP2_M1_C1" site2="RR7_RP2_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR7_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR7_PP1_M1" name="DorS">
+                <ListOfComponents>
+                  <Component id="RR7_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR7_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR7_PP2_M1" name="Wz" label="x">
+                <ListOfComponents>
+                  <Component id="RR7_PP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR7_PP2_M2" name="Wz">
+                <ListOfComponents>
+                  <Component id="RR7_PP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR7_PP2_B1" site1="RR7_PP2_M1_C1" site2="RR7_PP2_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR7_RateLaw" type="Function" name="_rateLaw1" totalrate="0">
+          <ListOfArguments>
+            <Argument id="x" type="ObjectReference" value="RR7_RP2_M1"/>
+          </ListOfArguments>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR7_RP1_M1" targetID="RR7_PP1_M1"/>
+          <MapItem sourceID="RR7_RP1_M1_C1" targetID="RR7_PP1_M1_C1"/>
+          <MapItem sourceID="RR7_RP2_M1" targetID="RR7_PP2_M1"/>
+          <MapItem sourceID="RR7_RP2_M1_C1" targetID="RR7_PP2_M1_C1"/>
+          <MapItem sourceID="RR7_RP2_M2" targetID="RR7_PP2_M2"/>
+          <MapItem sourceID="RR7_RP2_M2_C1" targetID="RR7_PP2_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR7_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR8" name="R_dor_asym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR8_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR8_RP1_M1" name="DorA">
+                <ListOfComponents>
+                  <Component id="RR8_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR8_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR8_RP2_M1" name="Yz">
+                <ListOfComponents>
+                  <Component id="RR8_RP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR8_RP2_M2" name="Zz" label="x">
+                <ListOfComponents>
+                  <Component id="RR8_RP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR8_RP2_B1" site1="RR8_RP2_M1_C1" site2="RR8_RP2_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR8_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR8_PP1_M1" name="DorA">
+                <ListOfComponents>
+                  <Component id="RR8_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR8_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR8_PP2_M1" name="Yz">
+                <ListOfComponents>
+                  <Component id="RR8_PP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR8_PP2_M2" name="Zz" label="x">
+                <ListOfComponents>
+                  <Component id="RR8_PP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR8_PP2_B1" site1="RR8_PP2_M1_C1" site2="RR8_PP2_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR8_RateLaw" type="Function" name="_rateLaw2" totalrate="0">
+          <ListOfArguments>
+            <Argument id="x" type="ObjectReference" value="RR8_RP2_M2"/>
+          </ListOfArguments>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR8_RP1_M1" targetID="RR8_PP1_M1"/>
+          <MapItem sourceID="RR8_RP1_M1_C1" targetID="RR8_PP1_M1_C1"/>
+          <MapItem sourceID="RR8_RP2_M1" targetID="RR8_PP2_M1"/>
+          <MapItem sourceID="RR8_RP2_M1_C1" targetID="RR8_PP2_M1_C1"/>
+          <MapItem sourceID="RR8_RP2_M2" targetID="RR8_PP2_M2"/>
+          <MapItem sourceID="RR8_RP2_M2_C1" targetID="RR8_PP2_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR8_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR9" name="R_mm_sym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR9_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR9_RP1_M1" name="MmS">
+                <ListOfComponents>
+                  <Component id="RR9_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR9_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR9_RP2_M1" name="Cz">
+                <ListOfComponents>
+                  <Component id="RR9_RP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR9_RP2_M2" name="Cz">
+                <ListOfComponents>
+                  <Component id="RR9_RP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR9_RP2_B1" site1="RR9_RP2_M1_C1" site2="RR9_RP2_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR9_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR9_PP1_M1" name="MmS">
+                <ListOfComponents>
+                  <Component id="RR9_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR9_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR9_PP2_M1" name="Cz">
+                <ListOfComponents>
+                  <Component id="RR9_PP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR9_PP2_M2" name="Cz">
+                <ListOfComponents>
+                  <Component id="RR9_PP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR9_PP2_B1" site1="RR9_PP2_M1_C1" site2="RR9_PP2_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR9_RateLaw" type="MM" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcatM"/>
+            <RateConstant value="Km"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR9_RP1_M1" targetID="RR9_PP1_M1"/>
+          <MapItem sourceID="RR9_RP1_M1_C1" targetID="RR9_PP1_M1_C1"/>
+          <MapItem sourceID="RR9_RP2_M1" targetID="RR9_PP2_M1"/>
+          <MapItem sourceID="RR9_RP2_M1_C1" targetID="RR9_PP2_M1_C1"/>
+          <MapItem sourceID="RR9_RP2_M2" targetID="RR9_PP2_M2"/>
+          <MapItem sourceID="RR9_RP2_M2_C1" targetID="RR9_PP2_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR9_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR10" name="R_mm_asym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR10_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR10_RP1_M1" name="MmA">
+                <ListOfComponents>
+                  <Component id="RR10_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR10_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR10_RP2_M1" name="Iz">
+                <ListOfComponents>
+                  <Component id="RR10_RP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR10_RP2_M2" name="Jz">
+                <ListOfComponents>
+                  <Component id="RR10_RP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR10_RP2_B1" site1="RR10_RP2_M1_C1" site2="RR10_RP2_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR10_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR10_PP1_M1" name="MmA">
+                <ListOfComponents>
+                  <Component id="RR10_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR10_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR10_PP2_M1" name="Iz">
+                <ListOfComponents>
+                  <Component id="RR10_PP2_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR10_PP2_M2" name="Jz">
+                <ListOfComponents>
+                  <Component id="RR10_PP2_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR10_PP2_B1" site1="RR10_PP2_M1_C1" site2="RR10_PP2_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR10_RateLaw" type="MM" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcatM"/>
+            <RateConstant value="Km"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR10_RP1_M1" targetID="RR10_PP1_M1"/>
+          <MapItem sourceID="RR10_RP1_M1_C1" targetID="RR10_PP1_M1_C1"/>
+          <MapItem sourceID="RR10_RP2_M1" targetID="RR10_PP2_M1"/>
+          <MapItem sourceID="RR10_RP2_M1_C1" targetID="RR10_PP2_M1_C1"/>
+          <MapItem sourceID="RR10_RP2_M2" targetID="RR10_PP2_M2"/>
+          <MapItem sourceID="RR10_RP2_M2_C1" targetID="RR10_PP2_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR10_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR11" name="R_subunit" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR11_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR11_RP1_M1" name="SubU">
+                <ListOfComponents>
+                  <Component id="RR11_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR11_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR11_RP2_M1" name="Ux">
+                <ListOfComponents>
+                  <Component id="RR11_RP2_M1_C1" name="d" numberOfBonds="+"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR11_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR11_PP1_M1" name="SubU">
+                <ListOfComponents>
+                  <Component id="RR11_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR11_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR11_PP2_M1" name="Ux">
+                <ListOfComponents>
+                  <Component id="RR11_PP2_M1_C1" name="d" numberOfBonds="+"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR11_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR11_RP1_M1" targetID="RR11_PP1_M1"/>
+          <MapItem sourceID="RR11_RP1_M1_C1" targetID="RR11_PP1_M1_C1"/>
+          <MapItem sourceID="RR11_RP2_M1" targetID="RR11_PP2_M1"/>
+          <MapItem sourceID="RR11_RP2_M1_C1" targetID="RR11_PP2_M1_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR11_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR12" name="R_scaffold" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR12_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR12_RP1_M1" name="SubV">
+                <ListOfComponents>
+                  <Component id="RR12_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR12_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR12_RP2_M1" name="Vx">
+                <ListOfComponents>
+                  <Component id="RR12_RP2_M1_C1" name="d" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR12_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR12_PP1_M1" name="SubV">
+                <ListOfComponents>
+                  <Component id="RR12_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR12_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR12_PP2_M1" name="Vx">
+                <ListOfComponents>
+                  <Component id="RR12_PP2_M1_C1" name="d" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR12_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR12_RP1_M1" targetID="RR12_PP1_M1"/>
+          <MapItem sourceID="RR12_RP1_M1_C1" targetID="RR12_PP1_M1_C1"/>
+          <MapItem sourceID="RR12_RP2_M1" targetID="RR12_PP2_M1"/>
+          <MapItem sourceID="RR12_RP2_M1_C1" targetID="RR12_PP2_M1_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR12_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR13" name="R_trimer" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR13_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR13_RP1_M1" name="SubT">
+                <ListOfComponents>
+                  <Component id="RR13_RP1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR13_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR13_RP2_M1" name="Tx">
+                <ListOfComponents>
+                  <Component id="RR13_RP2_M1_C1" name="a" numberOfBonds="+"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR13_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR13_PP1_M1" name="SubT">
+                <ListOfComponents>
+                  <Component id="RR13_PP1_M1_C1" name="s" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR13_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR13_PP2_M1" name="Tx">
+                <ListOfComponents>
+                  <Component id="RR13_PP2_M1_C1" name="a" numberOfBonds="+"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR13_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR13_RP1_M1" targetID="RR13_PP1_M1"/>
+          <MapItem sourceID="RR13_RP1_M1_C1" targetID="RR13_PP1_M1_C1"/>
+          <MapItem sourceID="RR13_RP2_M1" targetID="RR13_PP2_M1"/>
+          <MapItem sourceID="RR13_RP2_M1_C1" targetID="RR13_PP2_M1_C1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR13_RP1_M1_C1" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR14" name="R_bind_sym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR14_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR14_RP1_M1" name="BndS">
+                <ListOfComponents>
+                  <Component id="RR14_RP1_M1_C1" name="b" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR14_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR14_RP2_M1" name="Hz">
+                <ListOfComponents>
+                  <Component id="RR14_RP2_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR14_RP2_M1_C2" name="c" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR14_RP2_M2" name="Hz">
+                <ListOfComponents>
+                  <Component id="RR14_RP2_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR14_RP2_M2_C2" name="c" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR14_RP2_B1" site1="RR14_RP2_M1_C1" site2="RR14_RP2_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR14_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR14_PP1_M1" name="BndS">
+                <ListOfComponents>
+                  <Component id="RR14_PP1_M1_C1" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR14_PP1_M2" name="Hz">
+                <ListOfComponents>
+                  <Component id="RR14_PP1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR14_PP1_M2_C2" name="c" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR14_PP1_M3" name="Hz">
+                <ListOfComponents>
+                  <Component id="RR14_PP1_M3_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR14_PP1_M3_C2" name="c" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR14_PP1_B1" site1="RR14_PP1_M1_C1" site2="RR14_PP1_M2_C2"/>
+              <Bond id="RR14_PP1_B2" site1="RR14_PP1_M2_C1" site2="RR14_PP1_M3_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR14_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kb"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR14_RP1_M1" targetID="RR14_PP1_M1"/>
+          <MapItem sourceID="RR14_RP1_M1_C1" targetID="RR14_PP1_M1_C1"/>
+          <MapItem sourceID="RR14_RP2_M1" targetID="RR14_PP1_M2"/>
+          <MapItem sourceID="RR14_RP2_M1_C1" targetID="RR14_PP1_M2_C1"/>
+          <MapItem sourceID="RR14_RP2_M1_C2" targetID="RR14_PP1_M2_C2"/>
+          <MapItem sourceID="RR14_RP2_M2" targetID="RR14_PP1_M3"/>
+          <MapItem sourceID="RR14_RP2_M2_C1" targetID="RR14_PP1_M3_C1"/>
+          <MapItem sourceID="RR14_RP2_M2_C2" targetID="RR14_PP1_M3_C2"/>
+        </Map>
+        <ListOfOperations>
+          <AddBond site1="RR14_RP1_M1_C1" site2="RR14_RP2_M1_C2"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR15" name="R_bind_asym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR15_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR15_RP1_M1" name="BndA">
+                <ListOfComponents>
+                  <Component id="RR15_RP1_M1_C1" name="b" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR15_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR15_RP2_M1" name="Kz">
+                <ListOfComponents>
+                  <Component id="RR15_RP2_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR15_RP2_M1_C2" name="c" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR15_RP2_M2" name="Lz">
+                <ListOfComponents>
+                  <Component id="RR15_RP2_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR15_RP2_M2_C2" name="c" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR15_RP2_B1" site1="RR15_RP2_M1_C1" site2="RR15_RP2_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR15_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR15_PP1_M1" name="BndA">
+                <ListOfComponents>
+                  <Component id="RR15_PP1_M1_C1" name="b" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR15_PP1_M2" name="Kz">
+                <ListOfComponents>
+                  <Component id="RR15_PP1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR15_PP1_M2_C2" name="c" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR15_PP1_M3" name="Lz">
+                <ListOfComponents>
+                  <Component id="RR15_PP1_M3_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR15_PP1_M3_C2" name="c" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR15_PP1_B1" site1="RR15_PP1_M1_C1" site2="RR15_PP1_M2_C2"/>
+              <Bond id="RR15_PP1_B2" site1="RR15_PP1_M2_C1" site2="RR15_PP1_M3_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR15_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kb"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR15_RP1_M1" targetID="RR15_PP1_M1"/>
+          <MapItem sourceID="RR15_RP1_M1_C1" targetID="RR15_PP1_M1_C1"/>
+          <MapItem sourceID="RR15_RP2_M1" targetID="RR15_PP1_M2"/>
+          <MapItem sourceID="RR15_RP2_M1_C1" targetID="RR15_PP1_M2_C1"/>
+          <MapItem sourceID="RR15_RP2_M1_C2" targetID="RR15_PP1_M2_C2"/>
+          <MapItem sourceID="RR15_RP2_M2" targetID="RR15_PP1_M3"/>
+          <MapItem sourceID="RR15_RP2_M2_C1" targetID="RR15_PP1_M3_C1"/>
+          <MapItem sourceID="RR15_RP2_M2_C2" targetID="RR15_PP1_M3_C2"/>
+        </Map>
+        <ListOfOperations>
+          <AddBond site1="RR15_RP1_M1_C1" site2="RR15_RP2_M1_C2"/>
+        </ListOfOperations>
+      </ReactionRule>
+    </ListOfReactionRules>
+    <ListOfObservables>
+      <Observable id="O1" name="Obs_Src" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O1_P1">
+            <ListOfMolecules>
+              <Molecule id="O1_P1_M1" name="Src"/>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O2" name="Cnt_Wz" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O2_P1">
+            <ListOfMolecules>
+              <Molecule id="O2_P1_M1" name="Wz"/>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O3" name="Cnt_Zz" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O3_P1">
+            <ListOfMolecules>
+              <Molecule id="O3_P1_M1" name="Zz"/>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O4" name="Dim_sym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O4_P1">
+            <ListOfMolecules>
+              <Molecule id="O4_P1_M1" name="DimS">
+                <ListOfComponents>
+                  <Component id="O4_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O5" name="Dim_asym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O5_P1">
+            <ListOfMolecules>
+              <Molecule id="O5_P1_M1" name="DimA">
+                <ListOfComponents>
+                  <Component id="O5_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O6" name="Ring_sym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O6_P1">
+            <ListOfMolecules>
+              <Molecule id="O6_P1_M1" name="RingS">
+                <ListOfComponents>
+                  <Component id="O6_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O7" name="Ring_asym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O7_P1">
+            <ListOfMolecules>
+              <Molecule id="O7_P1_M1" name="RingA">
+                <ListOfComponents>
+                  <Component id="O7_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O8" name="Fn_sym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O8_P1">
+            <ListOfMolecules>
+              <Molecule id="O8_P1_M1" name="FnS">
+                <ListOfComponents>
+                  <Component id="O8_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O9" name="Fn_asym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O9_P1">
+            <ListOfMolecules>
+              <Molecule id="O9_P1_M1" name="FnA">
+                <ListOfComponents>
+                  <Component id="O9_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O10" name="Dor_sym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O10_P1">
+            <ListOfMolecules>
+              <Molecule id="O10_P1_M1" name="DorS">
+                <ListOfComponents>
+                  <Component id="O10_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O11" name="Dor_asym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O11_P1">
+            <ListOfMolecules>
+              <Molecule id="O11_P1_M1" name="DorA">
+                <ListOfComponents>
+                  <Component id="O11_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O12" name="Mm_sym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O12_P1">
+            <ListOfMolecules>
+              <Molecule id="O12_P1_M1" name="MmS">
+                <ListOfComponents>
+                  <Component id="O12_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O13" name="Mm_asym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O13_P1">
+            <ListOfMolecules>
+              <Molecule id="O13_P1_M1" name="MmA">
+                <ListOfComponents>
+                  <Component id="O13_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O14" name="Bind_sym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O14_P1">
+            <ListOfMolecules>
+              <Molecule id="O14_P1_M1" name="BndS">
+                <ListOfComponents>
+                  <Component id="O14_P1_M1_C1" name="b" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O15" name="Bind_asym" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O15_P1">
+            <ListOfMolecules>
+              <Molecule id="O15_P1_M1" name="BndA">
+                <ListOfComponents>
+                  <Component id="O15_P1_M1_C1" name="b" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O16" name="Sub_subunit" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O16_P1">
+            <ListOfMolecules>
+              <Molecule id="O16_P1_M1" name="SubU">
+                <ListOfComponents>
+                  <Component id="O16_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O17" name="Sub_scaffold" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O17_P1">
+            <ListOfMolecules>
+              <Molecule id="O17_P1_M1" name="SubV">
+                <ListOfComponents>
+                  <Component id="O17_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O18" name="Sub_trimer" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O18_P1">
+            <ListOfMolecules>
+              <Molecule id="O18_P1_M1" name="SubT">
+                <ListOfComponents>
+                  <Component id="O18_P1_M1_C1" name="s" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+    </ListOfObservables>
+    <ListOfFunctions>
+      <Function id="gfn">
+        <ListOfReferences>
+          <Reference name="kcat" type="Constant"/>
+          <Reference name="Obs_Src" type="Observable"/>
+        </ListOfReferences>
+        <Expression> kcat*Obs_Src </Expression>
+      </Function>
+      <Function id="locs">
+        <ListOfArguments>
+          <Argument id="x"/>
+        </ListOfArguments>
+        <ListOfReferences>
+          <Reference name="kcat" type="Constant"/>
+          <Reference name="x" type="Local"/>
+          <Reference name="Cnt_Wz" type="Observable"/>
+          <Reference name="Obs_Src" type="Observable"/>
+        </ListOfReferences>
+        <Expression> (kcat*Obs_Src)+(0*Cnt_Wz(x)) </Expression>
+      </Function>
+      <Function id="loca">
+        <ListOfArguments>
+          <Argument id="x"/>
+        </ListOfArguments>
+        <ListOfReferences>
+          <Reference name="kcat" type="Constant"/>
+          <Reference name="x" type="Local"/>
+          <Reference name="Cnt_Zz" type="Observable"/>
+          <Reference name="Obs_Src" type="Observable"/>
+        </ListOfReferences>
+        <Expression> (kcat*Obs_Src)+(0*Cnt_Zz(x)) </Expression>
+      </Function>
+      <Function id="_rateLaw1">
+        <ListOfArguments>
+          <Argument id="x"/>
+        </ListOfArguments>
+        <ListOfReferences>
+          <Reference name="locs" type="Function"/>
+          <Reference name="x" type="Local"/>
+        </ListOfReferences>
+        <Expression> locs(x) </Expression>
+      </Function>
+      <Function id="_rateLaw2">
+        <ListOfArguments>
+          <Argument id="x"/>
+        </ListOfArguments>
+        <ListOfReferences>
+          <Reference name="loca" type="Function"/>
+          <Reference name="x" type="Local"/>
+        </ListOfReferences>
+        <Expression> loca(x) </Expression>
+      </Function>
+    </ListOfFunctions>
+  </model>
+</sbml>

--- a/test/molecularity/ring2_homodimer.xml
+++ b/test/molecularity/ring2_homodimer.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by BioNetGen 2.9.3  -->
+<sbml xmlns="http://www.sbml.org/sbml/level3" level="3" version="1">
+  <model id="ring2_dimer">
+    <ListOfParameters>
+      <Parameter id="NA" type="Constant" value="6.022e+23" expr="6.022e23"/>
+      <Parameter id="V" type="Constant" value="2e-14" expr="2e-14"/>
+      <Parameter id="kf" type="Constant" value="8.3028894e-6" expr="1e5/(NA*V)"/>
+      <Parameter id="kr" type="Constant" value="0.0001" expr="1e-4"/>
+    </ListOfParameters>
+    <ListOfMoleculeTypes>
+      <MoleculeType id="M">
+        <ListOfComponentTypes>
+          <ComponentType id="h"/>
+          <ComponentType id="f"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+    </ListOfMoleculeTypes>
+    <ListOfCompartments>
+    </ListOfCompartments>
+    <ListOfSpecies>
+      <Species id="S1"  concentration="197" name="M(f!1,h!2).M(f!2,h!1)">
+        <ListOfMolecules>
+          <Molecule id="S1_M1" name="M">
+            <ListOfComponents>
+              <Component id="S1_M1_C1" name="f" numberOfBonds="1"/>
+              <Component id="S1_M1_C2" name="h" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S1_M2" name="M">
+            <ListOfComponents>
+              <Component id="S1_M2_C1" name="f" numberOfBonds="1"/>
+              <Component id="S1_M2_C2" name="h" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S1_B1" site1="S1_M1_C1" site2="S1_M2_C2"/>
+          <Bond id="S1_B2" site1="S1_M1_C2" site2="S1_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S2"  concentration="0" name="M(f,h)">
+        <ListOfMolecules>
+          <Molecule id="S2_M1" name="M">
+            <ListOfComponents>
+              <Component id="S2_M1_C1" name="f" numberOfBonds="0"/>
+              <Component id="S2_M1_C2" name="h" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+      </Species>
+    </ListOfSpecies>
+    <ListOfReactionRules>
+      <ReactionRule id="RR1" name="_R1" symmetry_factor="0.5">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR1_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_RP1_M1" name="M">
+                <ListOfComponents>
+                  <Component id="RR1_RP1_M1_C1" name="h" numberOfBonds="0"/>
+                  <Component id="RR1_RP1_M1_C2" name="f" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+          <ReactantPattern id="RR1_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR1_RP2_M1" name="M">
+                <ListOfComponents>
+                  <Component id="RR1_RP2_M1_C1" name="h" numberOfBonds="0"/>
+                  <Component id="RR1_RP2_M1_C2" name="f" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR1_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_PP1_M1" name="M">
+                <ListOfComponents>
+                  <Component id="RR1_PP1_M1_C1" name="h" numberOfBonds="1"/>
+                  <Component id="RR1_PP1_M1_C2" name="f" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR1_PP1_M2" name="M">
+                <ListOfComponents>
+                  <Component id="RR1_PP1_M2_C1" name="h" numberOfBonds="1"/>
+                  <Component id="RR1_PP1_M2_C2" name="f" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR1_PP1_B1" site1="RR1_PP1_M1_C1" site2="RR1_PP1_M2_C2"/>
+              <Bond id="RR1_PP1_B2" site1="RR1_PP1_M1_C2" site2="RR1_PP1_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR1_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kf"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR1_RP1_M1" targetID="RR1_PP1_M1"/>
+          <MapItem sourceID="RR1_RP1_M1_C1" targetID="RR1_PP1_M1_C1"/>
+          <MapItem sourceID="RR1_RP1_M1_C2" targetID="RR1_PP1_M1_C2"/>
+          <MapItem sourceID="RR1_RP2_M1" targetID="RR1_PP1_M2"/>
+          <MapItem sourceID="RR1_RP2_M1_C1" targetID="RR1_PP1_M2_C1"/>
+          <MapItem sourceID="RR1_RP2_M1_C2" targetID="RR1_PP1_M2_C2"/>
+        </Map>
+        <ListOfOperations>
+          <AddBond site1="RR1_RP1_M1_C1" site2="RR1_RP2_M1_C2"/>
+          <AddBond site1="RR1_RP1_M1_C2" site2="RR1_RP2_M1_C1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR2" name="_reverse__R1" symmetry_factor="0.5">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR2_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR2_RP1_M1" name="M">
+                <ListOfComponents>
+                  <Component id="RR2_RP1_M1_C1" name="h" numberOfBonds="1"/>
+                  <Component id="RR2_RP1_M1_C2" name="f" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR2_RP1_M2" name="M">
+                <ListOfComponents>
+                  <Component id="RR2_RP1_M2_C1" name="h" numberOfBonds="1"/>
+                  <Component id="RR2_RP1_M2_C2" name="f" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR2_RP1_B1" site1="RR2_RP1_M1_C1" site2="RR2_RP1_M2_C2"/>
+              <Bond id="RR2_RP1_B2" site1="RR2_RP1_M1_C2" site2="RR2_RP1_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR2_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR2_PP1_M1" name="M">
+                <ListOfComponents>
+                  <Component id="RR2_PP1_M1_C1" name="h" numberOfBonds="0"/>
+                  <Component id="RR2_PP1_M1_C2" name="f" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR2_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR2_PP2_M1" name="M">
+                <ListOfComponents>
+                  <Component id="RR2_PP2_M1_C1" name="h" numberOfBonds="0"/>
+                  <Component id="RR2_PP2_M1_C2" name="f" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR2_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kr"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR2_RP1_M1" targetID="RR2_PP1_M1"/>
+          <MapItem sourceID="RR2_RP1_M1_C1" targetID="RR2_PP1_M1_C1"/>
+          <MapItem sourceID="RR2_RP1_M1_C2" targetID="RR2_PP1_M1_C2"/>
+          <MapItem sourceID="RR2_RP1_M2" targetID="RR2_PP2_M1"/>
+          <MapItem sourceID="RR2_RP1_M2_C1" targetID="RR2_PP2_M1_C1"/>
+          <MapItem sourceID="RR2_RP1_M2_C2" targetID="RR2_PP2_M1_C2"/>
+        </Map>
+        <ListOfOperations>
+          <DeleteBond site1="RR2_RP1_M1_C1" site2="RR2_RP1_M2_C2"/>
+          <DeleteBond site1="RR2_RP1_M1_C2" site2="RR2_RP1_M2_C1"/>
+        </ListOfOperations>
+      </ReactionRule>
+    </ListOfReactionRules>
+    <ListOfObservables>
+      <Observable id="O1" name="Mtot" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O1_P1">
+            <ListOfMolecules>
+              <Molecule id="O1_P1_M1" name="M"/>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O2" name="dimers" type="Species">
+        <ListOfPatterns>
+          <Pattern id="O2_P1" matchOnce="1">
+            <ListOfMolecules>
+              <Molecule id="O2_P1_M1" name="M">
+                <ListOfComponents>
+                  <Component id="O2_P1_M1_C1" name="h" numberOfBonds="1"/>
+                  <Component id="O2_P1_M1_C2" name="f" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O2_P1_M2" name="M">
+                <ListOfComponents>
+                  <Component id="O2_P1_M2_C1" name="h" numberOfBonds="1"/>
+                  <Component id="O2_P1_M2_C2" name="f" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="O2_P1_B1" site1="O2_P1_M1_C1" site2="O2_P1_M2_C2"/>
+              <Bond id="O2_P1_B2" site1="O2_P1_M1_C2" site2="O2_P1_M2_C1"/>
+            </ListOfBonds>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O3" name="monomers" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O3_P1">
+            <ListOfMolecules>
+              <Molecule id="O3_P1_M1" name="M">
+                <ListOfComponents>
+                  <Component id="O3_P1_M1_C1" name="h" numberOfBonds="0"/>
+                  <Component id="O3_P1_M1_C2" name="f" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+    </ListOfObservables>
+    <ListOfFunctions>
+    </ListOfFunctions>
+  </model>
+</sbml>

--- a/test/molecularity/ring_singlebond.xml
+++ b/test/molecularity/ring_singlebond.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by BioNetGen 2.9.3  -->
+<sbml xmlns="http://www.sbml.org/sbml/level3" level="3" version="1">
+  <model id="ovl55_xml">
+    <ListOfParameters>
+      <Parameter id="koff" type="Constant" value="1" expr="1"/>
+      <Parameter id="nRings" type="Constant" value="100" expr="100"/>
+    </ListOfParameters>
+    <ListOfMoleculeTypes>
+      <MoleculeType id="L">
+        <ListOfComponentTypes>
+          <ComponentType id="r"/>
+          <ComponentType id="r"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="R">
+        <ListOfComponentTypes>
+          <ComponentType id="l"/>
+          <ComponentType id="l"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+    </ListOfMoleculeTypes>
+    <ListOfCompartments>
+    </ListOfCompartments>
+    <ListOfSpecies>
+      <Species id="S1"  concentration="nRings" name="L(r!1,r!2).L(r!3,r!4).R(l!2,l!3).R(l!4,l!1)">
+        <ListOfMolecules>
+          <Molecule id="S1_M1" name="L">
+            <ListOfComponents>
+              <Component id="S1_M1_C1" name="r" numberOfBonds="1"/>
+              <Component id="S1_M1_C2" name="r" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S1_M2" name="L">
+            <ListOfComponents>
+              <Component id="S1_M2_C1" name="r" numberOfBonds="1"/>
+              <Component id="S1_M2_C2" name="r" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S1_M3" name="R">
+            <ListOfComponents>
+              <Component id="S1_M3_C1" name="l" numberOfBonds="1"/>
+              <Component id="S1_M3_C2" name="l" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S1_M4" name="R">
+            <ListOfComponents>
+              <Component id="S1_M4_C1" name="l" numberOfBonds="1"/>
+              <Component id="S1_M4_C2" name="l" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S1_B1" site1="S1_M1_C1" site2="S1_M4_C2"/>
+          <Bond id="S1_B2" site1="S1_M1_C2" site2="S1_M3_C1"/>
+          <Bond id="S1_B3" site1="S1_M2_C1" site2="S1_M3_C2"/>
+          <Bond id="S1_B4" site1="S1_M2_C2" site2="S1_M4_C1"/>
+        </ListOfBonds>
+      </Species>
+    </ListOfSpecies>
+    <ListOfReactionRules>
+      <ReactionRule id="RR1" name="_R1" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR1_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_RP1_M1" name="L">
+                <ListOfComponents>
+                  <Component id="RR1_RP1_M1_C1" name="r" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR1_RP1_M2" name="R">
+                <ListOfComponents>
+                  <Component id="RR1_RP1_M2_C1" name="l" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR1_RP1_B1" site1="RR1_RP1_M1_C1" site2="RR1_RP1_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR1_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_PP1_M1" name="L">
+                <ListOfComponents>
+                  <Component id="RR1_PP1_M1_C1" name="r" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+          <ProductPattern id="RR1_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR1_PP2_M1" name="R">
+                <ListOfComponents>
+                  <Component id="RR1_PP2_M1_C1" name="l" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR1_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="koff"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR1_RP1_M1" targetID="RR1_PP1_M1"/>
+          <MapItem sourceID="RR1_RP1_M1_C1" targetID="RR1_PP1_M1_C1"/>
+          <MapItem sourceID="RR1_RP1_M2" targetID="RR1_PP2_M1"/>
+          <MapItem sourceID="RR1_RP1_M2_C1" targetID="RR1_PP2_M1_C1"/>
+        </Map>
+        <ListOfOperations>
+          <DeleteBond site1="RR1_RP1_M1_C1" site2="RR1_RP1_M2_C1"/>
+        </ListOfOperations>
+      </ReactionRule>
+    </ListOfReactionRules>
+    <ListOfObservables>
+      <Observable id="O1" name="Ring2" type="Species">
+        <ListOfPatterns>
+          <Pattern id="O1_P1" matchOnce="1">
+            <ListOfMolecules>
+              <Molecule id="O1_P1_M1" name="L">
+                <ListOfComponents>
+                  <Component id="O1_P1_M1_C1" name="r" numberOfBonds="1"/>
+                  <Component id="O1_P1_M1_C2" name="r" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O1_P1_M2" name="R">
+                <ListOfComponents>
+                  <Component id="O1_P1_M2_C1" name="l" numberOfBonds="1"/>
+                  <Component id="O1_P1_M2_C2" name="l" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O1_P1_M3" name="L">
+                <ListOfComponents>
+                  <Component id="O1_P1_M3_C1" name="r" numberOfBonds="1"/>
+                  <Component id="O1_P1_M3_C2" name="r" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O1_P1_M4" name="R">
+                <ListOfComponents>
+                  <Component id="O1_P1_M4_C1" name="l" numberOfBonds="1"/>
+                  <Component id="O1_P1_M4_C2" name="l" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="O1_P1_B1" site1="O1_P1_M1_C1" site2="O1_P1_M4_C2"/>
+              <Bond id="O1_P1_B2" site1="O1_P1_M1_C2" site2="O1_P1_M2_C1"/>
+              <Bond id="O1_P1_B3" site1="O1_P1_M2_C2" site2="O1_P1_M3_C1"/>
+              <Bond id="O1_P1_B4" site1="O1_P1_M3_C2" site2="O1_P1_M4_C1"/>
+            </ListOfBonds>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+    </ListOfObservables>
+    <ListOfFunctions>
+    </ListOfFunctions>
+  </model>
+</sbml>

--- a/test/symmetry/symmetry_factor_mm_saturated.bngl
+++ b/test/symmetry/symmetry_factor_mm_saturated.bngl
@@ -1,0 +1,69 @@
+# Michaelis-Menten symmetry correction ABOVE the linear regime.
+#
+# Companion to symmetry_factor_rate_laws.bngl, which keeps its MM pair far
+# below saturation. That fixture cannot tell the two placements of the symmetry
+# factor apart, because where the law is linear in the substrate match count
+# they coincide:
+#
+#     sigma * MM(2N, E)   ==   MM(sigma * 2N, E)      (linear regime only)
+#
+# Here X0/Km == 0.4, far enough into the law's nonlinear range that the two
+# placements separate by ~29 sigma while the pools still decay to a comfortable
+# ~1/5 of X0. (Pushing saturation harder, e.g. Km == X0, separates them further
+# in principle but decays the pools to ~75 counts, where Poisson noise eats the
+# gain.) What the factor corrects is a match multiplicity --
+# a symmetric substrate pattern matches each complex twice, so the law is
+# handed 2N when only N complexes exist. Scaling the substrate count is
+# therefore exact at any saturation; scaling the finished propensity is not.
+#
+# Measured at t=2000, 10 seeds (correct is agreement between the two rows):
+#
+#     no symmetry factor at all       sym  153.0    asym 754.8
+#     factor on the propensity        sym  977.0    asym 746.0
+#     factor on the substrate count   sym  758.0    asym 756.3
+#
+# The two rows are identical except for whether the substrate dimer's halves
+# are the same molecule type, so they must decay together. There is no closed
+# form to compare against -- the pairing IS the oracle.
+#
+# The enzyme is deliberately asymmetric. An MM rule does not transform its
+# enzyme, and BNG's MultScale counts reaction-center automorphisms, so an
+# enzyme-side symmetry gets symmetry_factor=1 and this factor is always the
+# substrate's. NFsim does over-count a symmetric context pattern, but that is
+# a separate defect with no symmetry_factor involved (issue #87).
+
+begin model
+begin parameters
+  kcat  1.0
+  Km    1.0e4      # X0/Km == 0.4: nonlinear, but not so deep that noise wins
+  X0    4000
+  Enz0  10
+end parameters
+
+begin molecule types
+  A(d,p~0~1)
+  P(d,p~0~1)
+  Q(d,p~0~1)
+  Enz()
+end molecule types
+
+begin seed species
+  Enz()                  Enz0
+  A(d!1,p~0).A(d!1,p~0)  X0
+  P(d!1,p~0).Q(d!1,p~0)  X0
+end seed species
+
+begin observables
+  Species   Sym_mm   A(d!1,p~0).A(d!1,p~0)
+  Species   Asym_mm  P(d!1,p~0).Q(d!1,p~0)
+end observables
+
+begin reaction rules
+  Rmm_sym:  A(d!1,p~0).A(d!1,p~0) + Enz() -> A(d!1,p~1).A(d!1,p~1) + Enz() MM(kcat,Km)
+  Rmm_asym: P(d!1,p~0).Q(d!1,p~0) + Enz() -> P(d!1,p~1).Q(d!1,p~1) + Enz() MM(kcat,Km)
+end reaction rules
+end model
+
+begin actions
+  writeXML()
+end actions

--- a/test/symmetry/symmetry_factor_mm_saturated.xml
+++ b/test/symmetry/symmetry_factor_mm_saturated.xml
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by BioNetGen 2.9.3  -->
+<sbml xmlns="http://www.sbml.org/sbml/level3" level="3" version="1">
+  <model id="symmetry_factor_mm_saturated">
+    <ListOfParameters>
+      <Parameter id="kcat" type="Constant" value="1" expr="1.0"/>
+      <Parameter id="Km" type="Constant" value="10000" expr="1.0e4"/>
+      <Parameter id="X0" type="Constant" value="4000" expr="4000"/>
+      <Parameter id="Enz0" type="Constant" value="10" expr="10"/>
+    </ListOfParameters>
+    <ListOfMoleculeTypes>
+      <MoleculeType id="A">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+          <ComponentType id="p">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Enz"/>
+      <MoleculeType id="P">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+          <ComponentType id="p">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Q">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+          <ComponentType id="p">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+    </ListOfMoleculeTypes>
+    <ListOfCompartments>
+    </ListOfCompartments>
+    <ListOfSpecies>
+      <Species id="S1"  concentration="Enz0" name="Enz()">
+        <ListOfMolecules>
+          <Molecule id="S1_M1" name="Enz"/>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S2"  concentration="X0" name="A(d!1,p~0).A(d!1,p~0)">
+        <ListOfMolecules>
+          <Molecule id="S2_M1" name="A">
+            <ListOfComponents>
+              <Component id="S2_M1_C1" name="d" numberOfBonds="1"/>
+              <Component id="S2_M1_C2" name="p" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S2_M2" name="A">
+            <ListOfComponents>
+              <Component id="S2_M2_C1" name="d" numberOfBonds="1"/>
+              <Component id="S2_M2_C2" name="p" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S2_B1" site1="S2_M1_C1" site2="S2_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S3"  concentration="X0" name="P(d!1,p~0).Q(d!1,p~0)">
+        <ListOfMolecules>
+          <Molecule id="S3_M1" name="P">
+            <ListOfComponents>
+              <Component id="S3_M1_C1" name="d" numberOfBonds="1"/>
+              <Component id="S3_M1_C2" name="p" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S3_M2" name="Q">
+            <ListOfComponents>
+              <Component id="S3_M2_C1" name="d" numberOfBonds="1"/>
+              <Component id="S3_M2_C2" name="p" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S3_B1" site1="S3_M1_C1" site2="S3_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+    </ListOfSpecies>
+    <ListOfReactionRules>
+      <ReactionRule id="RR1" name="Rmm_sym" symmetry_factor="0.5">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR1_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_RP1_M1" name="A">
+                <ListOfComponents>
+                  <Component id="RR1_RP1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR1_RP1_M1_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR1_RP1_M2" name="A">
+                <ListOfComponents>
+                  <Component id="RR1_RP1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR1_RP1_M2_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR1_RP1_B1" site1="RR1_RP1_M1_C1" site2="RR1_RP1_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+          <ReactantPattern id="RR1_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR1_RP2_M1" name="Enz"/>
+            </ListOfMolecules>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR1_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_PP1_M1" name="A">
+                <ListOfComponents>
+                  <Component id="RR1_PP1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR1_PP1_M1_C2" name="p" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR1_PP1_M2" name="A">
+                <ListOfComponents>
+                  <Component id="RR1_PP1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR1_PP1_M2_C2" name="p" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR1_PP1_B1" site1="RR1_PP1_M1_C1" site2="RR1_PP1_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+          <ProductPattern id="RR1_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR1_PP2_M1" name="Enz"/>
+            </ListOfMolecules>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR1_RateLaw" type="MM" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+            <RateConstant value="Km"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR1_RP1_M1" targetID="RR1_PP1_M1"/>
+          <MapItem sourceID="RR1_RP1_M1_C1" targetID="RR1_PP1_M1_C1"/>
+          <MapItem sourceID="RR1_RP1_M1_C2" targetID="RR1_PP1_M1_C2"/>
+          <MapItem sourceID="RR1_RP1_M2" targetID="RR1_PP1_M2"/>
+          <MapItem sourceID="RR1_RP1_M2_C1" targetID="RR1_PP1_M2_C1"/>
+          <MapItem sourceID="RR1_RP1_M2_C2" targetID="RR1_PP1_M2_C2"/>
+          <MapItem sourceID="RR1_RP2_M1" targetID="RR1_PP2_M1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR1_RP1_M1_C2" finalState="1"/>
+          <StateChange site="RR1_RP1_M2_C2" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR2" name="Rmm_asym" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR2_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR2_RP1_M1" name="P">
+                <ListOfComponents>
+                  <Component id="RR2_RP1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR2_RP1_M1_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR2_RP1_M2" name="Q">
+                <ListOfComponents>
+                  <Component id="RR2_RP1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR2_RP1_M2_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR2_RP1_B1" site1="RR2_RP1_M1_C1" site2="RR2_RP1_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+          <ReactantPattern id="RR2_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR2_RP2_M1" name="Enz"/>
+            </ListOfMolecules>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR2_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR2_PP1_M1" name="P">
+                <ListOfComponents>
+                  <Component id="RR2_PP1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR2_PP1_M1_C2" name="p" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR2_PP1_M2" name="Q">
+                <ListOfComponents>
+                  <Component id="RR2_PP1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR2_PP1_M2_C2" name="p" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR2_PP1_B1" site1="RR2_PP1_M1_C1" site2="RR2_PP1_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+          <ProductPattern id="RR2_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR2_PP2_M1" name="Enz"/>
+            </ListOfMolecules>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR2_RateLaw" type="MM" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+            <RateConstant value="Km"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR2_RP1_M1" targetID="RR2_PP1_M1"/>
+          <MapItem sourceID="RR2_RP1_M1_C1" targetID="RR2_PP1_M1_C1"/>
+          <MapItem sourceID="RR2_RP1_M1_C2" targetID="RR2_PP1_M1_C2"/>
+          <MapItem sourceID="RR2_RP1_M2" targetID="RR2_PP1_M2"/>
+          <MapItem sourceID="RR2_RP1_M2_C1" targetID="RR2_PP1_M2_C1"/>
+          <MapItem sourceID="RR2_RP1_M2_C2" targetID="RR2_PP1_M2_C2"/>
+          <MapItem sourceID="RR2_RP2_M1" targetID="RR2_PP2_M1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR2_RP1_M1_C2" finalState="1"/>
+          <StateChange site="RR2_RP1_M2_C2" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+    </ListOfReactionRules>
+    <ListOfObservables>
+      <Observable id="O1" name="Sym_mm" type="Species">
+        <ListOfPatterns>
+          <Pattern id="O1_P1" matchOnce="1">
+            <ListOfMolecules>
+              <Molecule id="O1_P1_M1" name="A">
+                <ListOfComponents>
+                  <Component id="O1_P1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="O1_P1_M1_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O1_P1_M2" name="A">
+                <ListOfComponents>
+                  <Component id="O1_P1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="O1_P1_M2_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="O1_P1_B1" site1="O1_P1_M1_C1" site2="O1_P1_M2_C1"/>
+            </ListOfBonds>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O2" name="Asym_mm" type="Species">
+        <ListOfPatterns>
+          <Pattern id="O2_P1" matchOnce="1">
+            <ListOfMolecules>
+              <Molecule id="O2_P1_M1" name="P">
+                <ListOfComponents>
+                  <Component id="O2_P1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="O2_P1_M1_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O2_P1_M2" name="Q">
+                <ListOfComponents>
+                  <Component id="O2_P1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="O2_P1_M2_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="O2_P1_B1" site1="O2_P1_M1_C1" site2="O2_P1_M2_C1"/>
+            </ListOfBonds>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+    </ListOfObservables>
+    <ListOfFunctions>
+    </ListOfFunctions>
+  </model>
+</sbml>

--- a/test/symmetry/symmetry_factor_rate_laws.bngl
+++ b/test/symmetry/symmetry_factor_rate_laws.bngl
@@ -1,0 +1,92 @@
+# Reaction center symmetry across every NFsim rate law type.
+#
+# Five dimer pools of X0 copies each decay with the same intended per-dimer
+# rate mu, under five different rate laws. Every pool must therefore follow
+# the same exponential X0*exp(-mu*t), regardless of whether its reactant
+# pattern is symmetric.
+#
+#   Rsym_fn   symmetric   global function    -> FunctionalRxnClass
+#   Rsym_k    symmetric   constant (Ele)     -> BasicRxnClass    (control: was already correct)
+#   Rasym_fn  asymmetric  global function    -> FunctionalRxnClass (control)
+#   Rsym_dor  symmetric   local function     -> DORRxnClass
+#   Rsym_mm   symmetric   Michaelis-Menten   -> MMRxnClass
+#   Rasym_mm  asymmetric  Michaelis-Menten   -> MMRxnClass       (control)
+#
+# BNG2.pl emits symmetry_factor="0.5" on each symmetric rule and "1" on each
+# asymmetric one, independently of rate law type. Before the fix only the Ele
+# path honored it, so the four symmetric non-Ele pools decayed at 2*mu.
+#
+# The MM pair is deliberately kept far below saturation (Km >> X0), where
+# NFsim's MM rate is linear in the substrate match count, so that one expected
+# value covers all five pools: kcat*Enz/Km == mu makes the MM pools decay at mu
+# like the rest.
+#
+# That linearity is also this fixture's blind spot. The symmetry factor
+# corrects a *match multiplicity*, and MM is not linear in that count, so
+# applying the factor to the substrate count and applying it to the finished
+# propensity give different answers -- but only above saturation. Down here
+# they are numerically identical, so this model cannot tell them apart.
+# symmetry_factor_mm_saturated.bngl is the one that can.
+
+begin model
+begin parameters
+  mu    1.0e-3
+  Km    1.0e7
+  Enz0  10
+  kcat  1.0e3       # kcat*Enz0/Km == mu
+  X0    4000
+end parameters
+
+begin molecule types
+  Src()
+  A(d)
+  B(d)
+  C(d)
+  D(d)
+  E(d)
+  G(d,p~0~1)
+  P(d,p~0~1)
+  Q(d,p~0~1)
+  Enz()
+end molecule types
+
+begin seed species
+  Src()                  1
+  Enz()                  Enz0
+  A(d!1).A(d!1)          X0
+  B(d!1).B(d!1)          X0
+  C(d!1).D(d!1)          X0
+  E(d!1).E(d!1)          X0
+  G(d!1,p~0).G(d!1,p~0)  X0
+  P(d!1,p~0).Q(d!1,p~0)  X0
+end seed species
+
+begin observables
+  Molecules Obs_Src  Src()
+  Molecules Cnt_E    E()
+  Species   Sym_fn   A(d!1).A(d!1)
+  Species   Sym_k    B(d!1).B(d!1)
+  Species   Asym_fn  C(d!1).D(d!1)
+  Species   Sym_dor  E(d!1).E(d!1)
+  Species   Sym_mm   G(d!1,p~0).G(d!1,p~0)
+  Species   Asym_mm  P(d!1,p~0).Q(d!1,p~0)
+end observables
+
+begin functions
+  glob()  = mu*Obs_Src
+  loc(x)  = mu*Obs_Src + 0*Cnt_E(x)
+end functions
+
+begin reaction rules
+  Rsym_fn:  A(d!1).A(d!1)   -> 0 glob() DeleteMolecules
+  Rsym_k:   B(d!1).B(d!1)   -> 0 mu     DeleteMolecules
+  Rasym_fn: C(d!1).D(d!1)   -> 0 glob() DeleteMolecules
+  Rsym_dor: E(d!1)%x.E(d!1) -> 0 loc(x) DeleteMolecules
+  Rsym_mm:  G(d!1,p~0).G(d!1,p~0) + Enz() -> G(d!1,p~1).G(d!1,p~1) + Enz() MM(kcat,Km)
+  Rasym_mm: P(d!1,p~0).Q(d!1,p~0) + Enz() -> P(d!1,p~1).Q(d!1,p~1) + Enz() MM(kcat,Km)
+end reaction rules
+end model
+
+begin actions
+  writeXML()
+end actions

--- a/test/symmetry/symmetry_factor_rate_laws.xml
+++ b/test/symmetry/symmetry_factor_rate_laws.xml
@@ -1,0 +1,674 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by BioNetGen 2.9.3  -->
+<sbml xmlns="http://www.sbml.org/sbml/level3" level="3" version="1">
+  <model id="symmetry_factor_rate_laws">
+    <ListOfParameters>
+      <Parameter id="mu" type="Constant" value="0.001" expr="1.0e-3"/>
+      <Parameter id="Km" type="Constant" value="10000000" expr="1.0e7"/>
+      <Parameter id="Enz0" type="Constant" value="10" expr="10"/>
+      <Parameter id="kcat" type="Constant" value="1000" expr="1.0e3"/>
+      <Parameter id="X0" type="Constant" value="4000" expr="4000"/>
+    </ListOfParameters>
+    <ListOfMoleculeTypes>
+      <MoleculeType id="A">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="B">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="C">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="D">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="E">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Enz"/>
+      <MoleculeType id="G">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+          <ComponentType id="p">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="P">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+          <ComponentType id="p">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Q">
+        <ListOfComponentTypes>
+          <ComponentType id="d"/>
+          <ComponentType id="p">
+            <ListOfAllowedStates>
+              <AllowedState id="0"/>
+              <AllowedState id="1"/>
+            </ListOfAllowedStates>
+          </ComponentType>
+        </ListOfComponentTypes>
+      </MoleculeType>
+      <MoleculeType id="Src"/>
+    </ListOfMoleculeTypes>
+    <ListOfCompartments>
+    </ListOfCompartments>
+    <ListOfSpecies>
+      <Species id="S1"  concentration="1" name="Src()">
+        <ListOfMolecules>
+          <Molecule id="S1_M1" name="Src"/>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S2"  concentration="Enz0" name="Enz()">
+        <ListOfMolecules>
+          <Molecule id="S2_M1" name="Enz"/>
+        </ListOfMolecules>
+      </Species>
+      <Species id="S3"  concentration="X0" name="A(d!1).A(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S3_M1" name="A">
+            <ListOfComponents>
+              <Component id="S3_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S3_M2" name="A">
+            <ListOfComponents>
+              <Component id="S3_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S3_B1" site1="S3_M1_C1" site2="S3_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S4"  concentration="X0" name="B(d!1).B(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S4_M1" name="B">
+            <ListOfComponents>
+              <Component id="S4_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S4_M2" name="B">
+            <ListOfComponents>
+              <Component id="S4_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S4_B1" site1="S4_M1_C1" site2="S4_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S5"  concentration="X0" name="C(d!1).D(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S5_M1" name="C">
+            <ListOfComponents>
+              <Component id="S5_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S5_M2" name="D">
+            <ListOfComponents>
+              <Component id="S5_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S5_B1" site1="S5_M1_C1" site2="S5_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S6"  concentration="X0" name="E(d!1).E(d!1)">
+        <ListOfMolecules>
+          <Molecule id="S6_M1" name="E">
+            <ListOfComponents>
+              <Component id="S6_M1_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S6_M2" name="E">
+            <ListOfComponents>
+              <Component id="S6_M2_C1" name="d" numberOfBonds="1"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S6_B1" site1="S6_M1_C1" site2="S6_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S7"  concentration="X0" name="G(d!1,p~0).G(d!1,p~0)">
+        <ListOfMolecules>
+          <Molecule id="S7_M1" name="G">
+            <ListOfComponents>
+              <Component id="S7_M1_C1" name="d" numberOfBonds="1"/>
+              <Component id="S7_M1_C2" name="p" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S7_M2" name="G">
+            <ListOfComponents>
+              <Component id="S7_M2_C1" name="d" numberOfBonds="1"/>
+              <Component id="S7_M2_C2" name="p" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S7_B1" site1="S7_M1_C1" site2="S7_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+      <Species id="S8"  concentration="X0" name="P(d!1,p~0).Q(d!1,p~0)">
+        <ListOfMolecules>
+          <Molecule id="S8_M1" name="P">
+            <ListOfComponents>
+              <Component id="S8_M1_C1" name="d" numberOfBonds="1"/>
+              <Component id="S8_M1_C2" name="p" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+          <Molecule id="S8_M2" name="Q">
+            <ListOfComponents>
+              <Component id="S8_M2_C1" name="d" numberOfBonds="1"/>
+              <Component id="S8_M2_C2" name="p" state="0" numberOfBonds="0"/>
+            </ListOfComponents>
+          </Molecule>
+        </ListOfMolecules>
+        <ListOfBonds>
+          <Bond id="S8_B1" site1="S8_M1_C1" site2="S8_M2_C1"/>
+        </ListOfBonds>
+      </Species>
+    </ListOfSpecies>
+    <ListOfReactionRules>
+      <ReactionRule id="RR1" name="Rsym_fn" symmetry_factor="0.5">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR1_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR1_RP1_M1" name="A">
+                <ListOfComponents>
+                  <Component id="RR1_RP1_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR1_RP1_M2" name="A">
+                <ListOfComponents>
+                  <Component id="RR1_RP1_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR1_RP1_B1" site1="RR1_RP1_M1_C1" site2="RR1_RP1_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+        </ListOfProductPatterns>
+        <RateLaw id="RR1_RateLaw" type="Function" name="glob" totalrate="0">
+          <ListOfArguments>
+          </ListOfArguments>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR1_RP1_M1"/>
+          <MapItem sourceID="RR1_RP1_M1_C1"/>
+          <MapItem sourceID="RR1_RP1_M2"/>
+          <MapItem sourceID="RR1_RP1_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <Delete id="RR1_RP1_M1" DeleteMolecules="1"/>
+          <Delete id="RR1_RP1_M2" DeleteMolecules="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR2" name="Rsym_k" symmetry_factor="0.5">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR2_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR2_RP1_M1" name="B">
+                <ListOfComponents>
+                  <Component id="RR2_RP1_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR2_RP1_M2" name="B">
+                <ListOfComponents>
+                  <Component id="RR2_RP1_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR2_RP1_B1" site1="RR2_RP1_M1_C1" site2="RR2_RP1_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+        </ListOfProductPatterns>
+        <RateLaw id="RR2_RateLaw" type="Ele" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="mu"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR2_RP1_M1"/>
+          <MapItem sourceID="RR2_RP1_M1_C1"/>
+          <MapItem sourceID="RR2_RP1_M2"/>
+          <MapItem sourceID="RR2_RP1_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <Delete id="RR2_RP1_M1" DeleteMolecules="1"/>
+          <Delete id="RR2_RP1_M2" DeleteMolecules="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR3" name="Rasym_fn" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR3_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR3_RP1_M1" name="C">
+                <ListOfComponents>
+                  <Component id="RR3_RP1_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR3_RP1_M2" name="D">
+                <ListOfComponents>
+                  <Component id="RR3_RP1_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR3_RP1_B1" site1="RR3_RP1_M1_C1" site2="RR3_RP1_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+        </ListOfProductPatterns>
+        <RateLaw id="RR3_RateLaw" type="Function" name="glob" totalrate="0">
+          <ListOfArguments>
+          </ListOfArguments>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR3_RP1_M1"/>
+          <MapItem sourceID="RR3_RP1_M1_C1"/>
+          <MapItem sourceID="RR3_RP1_M2"/>
+          <MapItem sourceID="RR3_RP1_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <Delete id="RR3_RP1_M1" DeleteMolecules="1"/>
+          <Delete id="RR3_RP1_M2" DeleteMolecules="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR4" name="Rsym_dor" symmetry_factor="0.5">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR4_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR4_RP1_M1" name="E" label="x">
+                <ListOfComponents>
+                  <Component id="RR4_RP1_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR4_RP1_M2" name="E">
+                <ListOfComponents>
+                  <Component id="RR4_RP1_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR4_RP1_B1" site1="RR4_RP1_M1_C1" site2="RR4_RP1_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+        </ListOfProductPatterns>
+        <RateLaw id="RR4_RateLaw" type="Function" name="_rateLaw1" totalrate="0">
+          <ListOfArguments>
+            <Argument id="x" type="ObjectReference" value="RR4_RP1_M1"/>
+          </ListOfArguments>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR4_RP1_M1"/>
+          <MapItem sourceID="RR4_RP1_M1_C1"/>
+          <MapItem sourceID="RR4_RP1_M2"/>
+          <MapItem sourceID="RR4_RP1_M2_C1"/>
+        </Map>
+        <ListOfOperations>
+          <Delete id="RR4_RP1_M1" DeleteMolecules="1"/>
+          <Delete id="RR4_RP1_M2" DeleteMolecules="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR5" name="Rsym_mm" symmetry_factor="0.5">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR5_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR5_RP1_M1" name="G">
+                <ListOfComponents>
+                  <Component id="RR5_RP1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR5_RP1_M1_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR5_RP1_M2" name="G">
+                <ListOfComponents>
+                  <Component id="RR5_RP1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR5_RP1_M2_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR5_RP1_B1" site1="RR5_RP1_M1_C1" site2="RR5_RP1_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+          <ReactantPattern id="RR5_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR5_RP2_M1" name="Enz"/>
+            </ListOfMolecules>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR5_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR5_PP1_M1" name="G">
+                <ListOfComponents>
+                  <Component id="RR5_PP1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR5_PP1_M1_C2" name="p" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR5_PP1_M2" name="G">
+                <ListOfComponents>
+                  <Component id="RR5_PP1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR5_PP1_M2_C2" name="p" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR5_PP1_B1" site1="RR5_PP1_M1_C1" site2="RR5_PP1_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+          <ProductPattern id="RR5_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR5_PP2_M1" name="Enz"/>
+            </ListOfMolecules>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR5_RateLaw" type="MM" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+            <RateConstant value="Km"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR5_RP1_M1" targetID="RR5_PP1_M1"/>
+          <MapItem sourceID="RR5_RP1_M1_C1" targetID="RR5_PP1_M1_C1"/>
+          <MapItem sourceID="RR5_RP1_M1_C2" targetID="RR5_PP1_M1_C2"/>
+          <MapItem sourceID="RR5_RP1_M2" targetID="RR5_PP1_M2"/>
+          <MapItem sourceID="RR5_RP1_M2_C1" targetID="RR5_PP1_M2_C1"/>
+          <MapItem sourceID="RR5_RP1_M2_C2" targetID="RR5_PP1_M2_C2"/>
+          <MapItem sourceID="RR5_RP2_M1" targetID="RR5_PP2_M1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR5_RP1_M1_C2" finalState="1"/>
+          <StateChange site="RR5_RP1_M2_C2" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+      <ReactionRule id="RR6" name="Rasym_mm" symmetry_factor="1">
+        <ListOfReactantPatterns>
+          <ReactantPattern id="RR6_RP1">
+            <ListOfMolecules>
+              <Molecule id="RR6_RP1_M1" name="P">
+                <ListOfComponents>
+                  <Component id="RR6_RP1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR6_RP1_M1_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR6_RP1_M2" name="Q">
+                <ListOfComponents>
+                  <Component id="RR6_RP1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR6_RP1_M2_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR6_RP1_B1" site1="RR6_RP1_M1_C1" site2="RR6_RP1_M2_C1"/>
+            </ListOfBonds>
+          </ReactantPattern>
+          <ReactantPattern id="RR6_RP2">
+            <ListOfMolecules>
+              <Molecule id="RR6_RP2_M1" name="Enz"/>
+            </ListOfMolecules>
+          </ReactantPattern>
+        </ListOfReactantPatterns>
+        <ListOfProductPatterns>
+          <ProductPattern id="RR6_PP1">
+            <ListOfMolecules>
+              <Molecule id="RR6_PP1_M1" name="P">
+                <ListOfComponents>
+                  <Component id="RR6_PP1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR6_PP1_M1_C2" name="p" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="RR6_PP1_M2" name="Q">
+                <ListOfComponents>
+                  <Component id="RR6_PP1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="RR6_PP1_M2_C2" name="p" state="1" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="RR6_PP1_B1" site1="RR6_PP1_M1_C1" site2="RR6_PP1_M2_C1"/>
+            </ListOfBonds>
+          </ProductPattern>
+          <ProductPattern id="RR6_PP2">
+            <ListOfMolecules>
+              <Molecule id="RR6_PP2_M1" name="Enz"/>
+            </ListOfMolecules>
+          </ProductPattern>
+        </ListOfProductPatterns>
+        <RateLaw id="RR6_RateLaw" type="MM" totalrate="0">
+          <ListOfRateConstants>
+            <RateConstant value="kcat"/>
+            <RateConstant value="Km"/>
+          </ListOfRateConstants>
+        </RateLaw>
+        <Map>
+          <MapItem sourceID="RR6_RP1_M1" targetID="RR6_PP1_M1"/>
+          <MapItem sourceID="RR6_RP1_M1_C1" targetID="RR6_PP1_M1_C1"/>
+          <MapItem sourceID="RR6_RP1_M1_C2" targetID="RR6_PP1_M1_C2"/>
+          <MapItem sourceID="RR6_RP1_M2" targetID="RR6_PP1_M2"/>
+          <MapItem sourceID="RR6_RP1_M2_C1" targetID="RR6_PP1_M2_C1"/>
+          <MapItem sourceID="RR6_RP1_M2_C2" targetID="RR6_PP1_M2_C2"/>
+          <MapItem sourceID="RR6_RP2_M1" targetID="RR6_PP2_M1"/>
+        </Map>
+        <ListOfOperations>
+          <StateChange site="RR6_RP1_M1_C2" finalState="1"/>
+          <StateChange site="RR6_RP1_M2_C2" finalState="1"/>
+        </ListOfOperations>
+      </ReactionRule>
+    </ListOfReactionRules>
+    <ListOfObservables>
+      <Observable id="O1" name="Obs_Src" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O1_P1">
+            <ListOfMolecules>
+              <Molecule id="O1_P1_M1" name="Src"/>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O2" name="Cnt_E" type="Molecules">
+        <ListOfPatterns>
+          <Pattern id="O2_P1">
+            <ListOfMolecules>
+              <Molecule id="O2_P1_M1" name="E"/>
+            </ListOfMolecules>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O3" name="Sym_fn" type="Species">
+        <ListOfPatterns>
+          <Pattern id="O3_P1" matchOnce="1">
+            <ListOfMolecules>
+              <Molecule id="O3_P1_M1" name="A">
+                <ListOfComponents>
+                  <Component id="O3_P1_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O3_P1_M2" name="A">
+                <ListOfComponents>
+                  <Component id="O3_P1_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="O3_P1_B1" site1="O3_P1_M1_C1" site2="O3_P1_M2_C1"/>
+            </ListOfBonds>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O4" name="Sym_k" type="Species">
+        <ListOfPatterns>
+          <Pattern id="O4_P1" matchOnce="1">
+            <ListOfMolecules>
+              <Molecule id="O4_P1_M1" name="B">
+                <ListOfComponents>
+                  <Component id="O4_P1_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O4_P1_M2" name="B">
+                <ListOfComponents>
+                  <Component id="O4_P1_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="O4_P1_B1" site1="O4_P1_M1_C1" site2="O4_P1_M2_C1"/>
+            </ListOfBonds>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O5" name="Asym_fn" type="Species">
+        <ListOfPatterns>
+          <Pattern id="O5_P1" matchOnce="1">
+            <ListOfMolecules>
+              <Molecule id="O5_P1_M1" name="C">
+                <ListOfComponents>
+                  <Component id="O5_P1_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O5_P1_M2" name="D">
+                <ListOfComponents>
+                  <Component id="O5_P1_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="O5_P1_B1" site1="O5_P1_M1_C1" site2="O5_P1_M2_C1"/>
+            </ListOfBonds>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O6" name="Sym_dor" type="Species">
+        <ListOfPatterns>
+          <Pattern id="O6_P1" matchOnce="1">
+            <ListOfMolecules>
+              <Molecule id="O6_P1_M1" name="E">
+                <ListOfComponents>
+                  <Component id="O6_P1_M1_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O6_P1_M2" name="E">
+                <ListOfComponents>
+                  <Component id="O6_P1_M2_C1" name="d" numberOfBonds="1"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="O6_P1_B1" site1="O6_P1_M1_C1" site2="O6_P1_M2_C1"/>
+            </ListOfBonds>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O7" name="Sym_mm" type="Species">
+        <ListOfPatterns>
+          <Pattern id="O7_P1" matchOnce="1">
+            <ListOfMolecules>
+              <Molecule id="O7_P1_M1" name="G">
+                <ListOfComponents>
+                  <Component id="O7_P1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="O7_P1_M1_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O7_P1_M2" name="G">
+                <ListOfComponents>
+                  <Component id="O7_P1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="O7_P1_M2_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="O7_P1_B1" site1="O7_P1_M1_C1" site2="O7_P1_M2_C1"/>
+            </ListOfBonds>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+      <Observable id="O8" name="Asym_mm" type="Species">
+        <ListOfPatterns>
+          <Pattern id="O8_P1" matchOnce="1">
+            <ListOfMolecules>
+              <Molecule id="O8_P1_M1" name="P">
+                <ListOfComponents>
+                  <Component id="O8_P1_M1_C1" name="d" numberOfBonds="1"/>
+                  <Component id="O8_P1_M1_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+              <Molecule id="O8_P1_M2" name="Q">
+                <ListOfComponents>
+                  <Component id="O8_P1_M2_C1" name="d" numberOfBonds="1"/>
+                  <Component id="O8_P1_M2_C2" name="p" state="0" numberOfBonds="0"/>
+                </ListOfComponents>
+              </Molecule>
+            </ListOfMolecules>
+            <ListOfBonds>
+              <Bond id="O8_P1_B1" site1="O8_P1_M1_C1" site2="O8_P1_M2_C1"/>
+            </ListOfBonds>
+          </Pattern>
+        </ListOfPatterns>
+      </Observable>
+    </ListOfObservables>
+    <ListOfFunctions>
+      <Function id="glob">
+        <ListOfReferences>
+          <Reference name="mu" type="Constant"/>
+          <Reference name="Obs_Src" type="Observable"/>
+        </ListOfReferences>
+        <Expression> mu*Obs_Src </Expression>
+      </Function>
+      <Function id="loc">
+        <ListOfArguments>
+          <Argument id="x"/>
+        </ListOfArguments>
+        <ListOfReferences>
+          <Reference name="mu" type="Constant"/>
+          <Reference name="x" type="Local"/>
+          <Reference name="Cnt_E" type="Observable"/>
+          <Reference name="Obs_Src" type="Observable"/>
+        </ListOfReferences>
+        <Expression> (mu*Obs_Src)+(0*Cnt_E(x)) </Expression>
+      </Function>
+      <Function id="_rateLaw1">
+        <ListOfArguments>
+          <Argument id="x"/>
+        </ListOfArguments>
+        <ListOfReferences>
+          <Reference name="loc" type="Function"/>
+          <Reference name="x" type="Local"/>
+        </ListOfReferences>
+        <Expression> loc(x) </Expression>
+      </Function>
+    </ListOfFunctions>
+  </model>
+</sbml>

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -674,6 +674,44 @@ class TestIssueRegressions(unittest.TestCase):
                     "regressed".format(rings, seed),
                 )
 
+    def test_species_observable_counts_without_a_bookkeeping_flag(self):
+        # System.useComplex used to be derived solely from blockSameComplexBinding.
+        # A Species-typed observable is tallied by iterating complexes, so run
+        # without complex bookkeeping it was counted with tracking disabled and
+        # reported a number with no physical ceiling.
+        #
+        # ring2_homodimer.xml declares the Species observable `dimers` over 197
+        # two-bond rings, so the count can never exceed 197. Run with no flags at
+        # all, it used to report ~3612. It must now be physical, and agree with the
+        # bookkeeping-enabled run -- this model has no same-complex binding, so the
+        # two modes describe the same trajectory.
+        xmlPath = os.path.join(
+            nfsimPrePath, "test", "molecularity", "ring2_homodimer.xml"
+        )
+        headers, noFlags = self._mean_final_row(xmlPath, "-sim 200000 -oSteps 2", 3)
+        _, withBscb = self._mean_final_row(xmlPath, "-sim 200000 -oSteps 2 -bscb", 3)
+
+        seeded = 197.0
+        dimers = noFlags[headers.index("dimers")]
+        self.assertLessEqual(
+            dimers,
+            seeded,
+            "the Species observable reported {0:.1f} dimers with no bookkeeping "
+            "flag, but only {1:.0f} rings were ever seeded -- complex tracking is "
+            "not on for a model that needs it".format(dimers, seeded),
+        )
+        self.assertAlmostEqual(
+            dimers,
+            withBscb[headers.index("dimers")],
+            delta=20.0,
+            msg="the Species observable disagrees between the default run and the "
+            "-bscb run, which describe the same trajectory for this model",
+        )
+        # The molecules themselves were always counted correctly; it is only the
+        # complex-level tally that was wrong. Guards against "fixing" the count by
+        # perturbing the underlying simulation.
+        self.assertAlmostEqual(noFlags[headers.index("Mtot")], 394.0, delta=1e-6)
+
     def test_tfun_inline_time_outputs_expected_global_function(self):
         outputDirectory = mfolder
         fileNumber = "44"

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -712,6 +712,120 @@ class TestIssueRegressions(unittest.TestCase):
         # perturbing the underlying simulation.
         self.assertAlmostEqual(noFlags[headers.index("Mtot")], 394.0, delta=1e-6)
 
+    def test_pure_context_reactant_is_counted_once_per_complex(self):
+        # Issue #87. BioNetGen gives a reactant pattern the rule does not transform
+        # one reaction instance per matching complex, however many molecules inside
+        # that complex match it, because every embedding yields the identical
+        # reaction. NFsim enumerated matches per molecule, so a homodimeric
+        # catalyst drove its rule twice as fast as a heterodimeric one and a
+        # homotrimer ring three times as fast.
+        #
+        # Every pool below carries the same intended per-substrate rate
+        # mu = kcat*E0 = 2.5e-4, so the oracle is BNG's own generated network
+        # integrated as ODEs: X0*exp(-mu*t) = 4000*exp(-0.5) = 2426.1. The
+        # Michaelis-Menten pair has no closed form and lands at 2344.8.
+        xmlPath = os.path.join(nfsimPrePath, "test", "context", "context_symmetry.xml")
+        headers, mean = self._mean_final_row(xmlPath, "-sim 2000 -oSteps 2 -cb", 10)
+
+        expected = 4000.0 * np.exp(-0.5)
+        expectedMM = 2344.8
+        # Per-seed scatter is ~30 counts, so a 10-seed mean has sigma ~10. A +/-100
+        # band is ~10 sigma wide and leaves every over-counted value (~1471 at 2x,
+        # ~893 at 3x) more than 900 counts outside it.
+        tolerance = 100.0
+
+        pools = [
+            ("Dim_sym", "homodimer catalyst, constant rate", expected),
+            ("Fn_sym", "homodimer catalyst, global function", expected),
+            ("Dor_sym", "homodimer catalyst, local function", expected),
+            ("Mm_sym", "symmetric enzyme, Michaelis-Menten", expectedMM),
+            ("Ring_sym", "homotrimer ring catalyst (3x, not 2x)", expected),
+            ("Sub_subunit", "single-subunit pattern against a homodimer", expected),
+            # The load-bearing case: a single-molecule pattern against a complex
+            # holding two *distinguishable* copies. No automorphism anywhere, and
+            # still over-counted -- which rules out embeddings/|Aut(pattern)|.
+            ("Sub_scaffold", "two distinguishable copies, no symmetry at all", expected),
+            # Sharper still: single-molecule pattern against a homotrimer ring, so
+            # embeddings/|Aut| would say 3, a hardcoded factor of two 1.5, and
+            # once-per-complex 1. BNG says 1.
+            ("Sub_trimer", "single-molecule pattern against a homotrimer ring", expected),
+        ]
+        for name, description, want in pools:
+            got = mean[headers.index(name)]
+            self.assertAlmostEqual(
+                got,
+                want,
+                delta=tolerance,
+                msg="{0} ({1}) ended at {2:.1f}, expected about {3:.1f}; a value "
+                "near 1471 means two matching molecules in one complex were "
+                "counted as two reaction instances, near 893 means three".format(
+                    name, description, got, want
+                ),
+            )
+
+        # Needs no oracle: two catalysts present at the same complex count and
+        # carrying the same rate constant must give the same rate, whatever the
+        # rate law.
+        for multi, single, rateLaw in [
+            ("Dim_sym", "Dim_asym", "constant rate"),
+            ("Ring_sym", "Ring_asym", "constant rate, trimer ring"),
+            ("Fn_sym", "Fn_asym", "global function"),
+            ("Dor_sym", "Dor_asym", "local function"),
+            ("Mm_sym", "Mm_asym", "Michaelis-Menten"),
+        ]:
+            many = mean[headers.index(multi)]
+            one = mean[headers.index(single)]
+            self.assertAlmostEqual(
+                many,
+                one,
+                delta=2 * tolerance,
+                msg="{0}: multi-subunit catalyst ended at {1:.1f}, single-subunit "
+                "control at {2:.1f}".format(rateLaw, many, one),
+            )
+
+    def test_a_transformed_symmetric_pattern_keeps_both_of_its_sites(self):
+        # The other direction, and the reason "which reactants are pure context"
+        # has to be decided before finalize() appends its placeholder. Bind_sym's
+        # catalyst dimer IS transformed -- one half of it binds -- so its two
+        # halves are two genuinely distinct reactive sites and two distinct
+        # reactions. BNG agrees explicitly: the generated network gives this rule
+        # 2*kb where the heterodimer control gets kb.
+        #
+        # NFsim marks the second partner of a binding with an EMPTY transform, the
+        # same type finalize() uses for its placeholder, so deciding pure context
+        # from the transformation types afterwards misclassifies exactly this rule
+        # and erases its factor of two -- landing it on top of its own control.
+        xmlPath = os.path.join(nfsimPrePath, "test", "context", "context_symmetry.xml")
+        headers, mean = self._mean_final_row(xmlPath, "-sim 2000 -oSteps 2 -cb", 10)
+
+        sym = mean[headers.index("Bind_sym")]
+        asym = mean[headers.index("Bind_asym")]
+        self.assertAlmostEqual(
+            sym,
+            218.0,
+            delta=25.0,
+            msg="Bind_sym ended at {0:.1f}, expected about 218. A value near its "
+            "control ({1:.1f}) means per-complex counting reached a reactant the "
+            "rule transforms and divided out a factor BNG put there on "
+            "purpose".format(sym, asym),
+        )
+        self.assertAlmostEqual(
+            asym,
+            320.0,
+            delta=30.0,
+            msg="Bind_asym ended at {0:.1f}, expected about 320. This rule has one "
+            "reactive site and one matching molecule per complex, so nothing here "
+            "should move it".format(asym),
+        )
+        # Guard the pair: the two assertions above only discriminate while the
+        # two-site arm actually runs faster than its control.
+        self.assertGreater(
+            asym - sym,
+            50.0,
+            "Bind_sym and Bind_asym have converged -- this pair no longer tells a "
+            "transformed pattern's real multiplicity from a context over-count",
+        )
+
     def test_tfun_inline_time_outputs_expected_global_function(self):
         outputDirectory = mfolder
         fileNumber = "44"

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -617,6 +617,63 @@ class TestIssueRegressions(unittest.TestCase):
             "-- this fixture no longer probes the nonlinear range".format(asym),
         )
 
+    def test_multibond_ring_opening_dissociation_can_fire(self):
+        # Product molecularity for a unimolecular unbinding rule used to be tested
+        # one deleted bond at a time. For a rule that opens a cyclic complex by
+        # deleting several bonds at once that is the wrong question: each ring bond
+        # alone leaves the partners connected through the others, so the check
+        # refused every one of them and the dissociation never fired.
+        #
+        # 197 copies of the two-bond ring M(h!1,f!2).M(h!2,f!1), whose only reaction
+        # is the reverse homodimerization deleting both ring bonds. BNG's
+        # generate_network() integrated as ODEs relaxes to about 63 free monomers.
+        # Before the fix the monomer count stayed pinned at 0.
+        xmlPath = os.path.join(
+            nfsimPrePath, "test", "molecularity", "ring2_homodimer.xml"
+        )
+        headers, mean = self._mean_final_row(xmlPath, "-sim 200000 -oSteps 2 -bscb", 3)
+
+        # Conservation first: 197 rings is 394 monomer-equivalents of M.
+        self.assertAlmostEqual(mean[headers.index("Mtot")], 394.0, delta=1e-6)
+
+        monomers = mean[headers.index("monomers")]
+        # The decisive contrast is 0 (trapped) against the ~63 equilibrium, so a
+        # generous band still separates the two hypotheses completely.
+        self.assertGreater(
+            monomers,
+            30.0,
+            "the two-bond ring did not dissociate (monomers={0:.1f}); the "
+            "product-molecularity check is still being applied one bond at a "
+            "time".format(monomers),
+        )
+        self.assertLess(monomers, 110.0)
+
+    def test_singlebond_ring_dissociation_stays_blocked(self):
+        # The negative control, and the behavior issues #48 and #61 produced:
+        # 100 copies of a size-2 ring whose rule deletes a single L-R bond, which
+        # leaves the partners connected through the rest of the cycle. The products
+        # do not separate, the network generator drops the reaction, and the ring
+        # count must stay at 100 exactly -- no variance across seeds.
+        xmlPath = os.path.join(
+            nfsimPrePath, "test", "molecularity", "ring_singlebond.xml"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for seed in (1, 2, 3):
+                outPath = os.path.join(tmpdir, "ring_{0}.gdat".format(seed))
+                self._run_nfsim_xml(
+                    xmlPath, outPath, "-sim 5 -oSteps 1 -bscb -seed {0}".format(seed)
+                )
+                headers, data = self._load_gdat(outPath)
+                rings = data[-1][headers.index("Ring2")]
+                self.assertAlmostEqual(
+                    rings,
+                    100.0,
+                    delta=1e-6,
+                    msg="a single-bond break inside a ring fired (Ring2={0}, "
+                    "seed={1}); product-molecularity enforcement has "
+                    "regressed".format(rings, seed),
+                )
+
     def test_tfun_inline_time_outputs_expected_global_function(self):
         outputDirectory = mfolder
         fileNumber = "44"

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -500,6 +500,123 @@ class TestIssueRegressions(unittest.TestCase):
                 ),
             )
 
+    def _mean_final_row(self, xmlPath, runOptions, nSeeds):
+        """Mean of the final output row over seeds 1..nSeeds. Returns (headers, row)."""
+        total = None
+        headers = None
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for seed in range(1, nSeeds + 1):
+                outPath = os.path.join(tmpdir, "run_{0}.gdat".format(seed))
+                self._run_nfsim_xml(
+                    xmlPath, outPath, "{0} -seed {1}".format(runOptions, seed)
+                )
+                headers, data = self._load_gdat(outPath)
+                total = data if total is None else total + data
+        return headers, (total / nSeeds)[-1]
+
+    def test_symmetry_factor_is_applied_on_every_rate_law(self):
+        # ReactionClass's constructor scaled its own baseRate *argument*, which the
+        # member had already been copied out of, so the symmetry correction was
+        # computed and discarded. Only Ele recovered it, via setBaseRate(). Every
+        # other rate law is built with baseRate=1 and never calls setBaseRate, so a
+        # rule whose reactant pattern has a non-trivial automorphism ran at
+        # 1/symmetry_factor times its intended rate -- 2x for a homodimer.
+        #
+        # Five dimer pools of X0 copies decay under five rate laws that all encode
+        # the same intended per-dimer rate mu, so one expected value covers them
+        # all: X0*exp(-mu*t) = 4000*exp(-1) = 1471.5. A dropped factor gives
+        # 4000*exp(-2) = 541.3 instead, which is nowhere near it.
+        xmlPath = os.path.join(
+            nfsimPrePath, "test", "symmetry", "symmetry_factor_rate_laws.xml"
+        )
+        headers, mean = self._mean_final_row(xmlPath, "-sim 1000 -oSteps 2 -cb", 5)
+
+        expected = 4000.0 * np.exp(-1.0)
+        # Per-seed scatter is ~30 counts, so a 5-seed mean has sigma ~13. A +/-170
+        # band is ~13 sigma wide and still leaves the dropped-factor value 930
+        # counts outside it.
+        tolerance = 170.0
+
+        pools = [
+            ("Sym_fn", "symmetric, global function (FunctionalRxnClass)"),
+            ("Sym_dor", "symmetric, local function (DORRxnClass)"),
+            ("Sym_mm", "symmetric, Michaelis-Menten (MMRxnClass)"),
+            # These three were already correct; they guard against applying the
+            # factor twice, or applying it to an asymmetric rule.
+            ("Sym_k", "symmetric, constant rate (BasicRxnClass, control)"),
+            ("Asym_fn", "asymmetric, global function (control)"),
+            ("Asym_mm", "asymmetric, Michaelis-Menten (control)"),
+        ]
+        for name, description in pools:
+            got = mean[headers.index(name)]
+            self.assertAlmostEqual(
+                got,
+                expected,
+                delta=tolerance,
+                msg="{0} ({1}) ended at {2:.1f}, expected about {3:.1f}; "
+                "{4:.1f} means the symmetry factor was dropped".format(
+                    name, description, got, expected, 4000.0 * np.exp(-2.0)
+                ),
+            )
+
+        # The sharpest form of the claim, needing no expected value at all: a
+        # rule's decay must not depend on whether its reactant pattern happens
+        # to be symmetric.
+        for symName, asymName, rateLaw in [
+            ("Sym_fn", "Asym_fn", "global function"),
+            ("Sym_mm", "Asym_mm", "Michaelis-Menten"),
+        ]:
+            sym = mean[headers.index(symName)]
+            asym = mean[headers.index(asymName)]
+            self.assertAlmostEqual(
+                sym,
+                asym,
+                delta=2 * tolerance,
+                msg="{0}: symmetric pool ended at {1:.1f}, asymmetric at {2:.1f}".format(
+                    rateLaw, sym, asym
+                ),
+            )
+
+    def test_michaelis_menten_symmetry_factor_scales_the_substrate_count(self):
+        # Where the MM law is linear in the substrate match count, scaling that
+        # count and scaling the finished propensity coincide, so the fixture above
+        # cannot tell them apart. This one sits at X0/Km = 0.4, where they
+        # separate. The two rules differ only in whether the substrate dimer's
+        # halves are the same molecule type, so they must decay together; there is
+        # no closed form here and the pairing is the oracle.
+        #
+        # Measured over 10 seeds at t=2000:
+        #     no factor at all              sym 164.4   asym 761.2
+        #     factor on the propensity      sym 993.9   asym 751.8
+        #     factor on the substrate count sym 758.0   asym 756.3
+        xmlPath = os.path.join(
+            nfsimPrePath, "test", "symmetry", "symmetry_factor_mm_saturated.xml"
+        )
+        headers, mean = self._mean_final_row(xmlPath, "-sim 2000 -oSteps 2 -cb", 10)
+
+        sym = mean[headers.index("Sym_mm")]
+        asym = mean[headers.index("Asym_mm")]
+        # Per-seed scatter is ~25 counts, so a 10-seed mean has sigma ~8. An
+        # 80-count band is ~10 sigma wide and leaves the propensity placement's
+        # ~240 gap far outside.
+        self.assertAlmostEqual(
+            sym,
+            asym,
+            delta=80.0,
+            msg="saturated MM: symmetric ended at {0:.1f}, asymmetric at {1:.1f}. A "
+            "gap near +240 means the factor is being applied to the finished "
+            "propensity instead of to the substrate count".format(sym, asym),
+        )
+        # Guard the fixture itself: if a parameter edit drifted this model back
+        # into the linear regime the assertion above would keep passing while
+        # having stopped discriminating. Linear-regime decay leaves ~1471.
+        self.assertLess(
+            asym,
+            1100.0,
+            "the MM control ended at {0:.1f}, too close to the linear-regime value "
+            "-- this fixture no longer probes the nonlinear range".format(asym),
+        )
+
     def test_tfun_inline_time_outputs_expected_global_function(self):
         outputDirectory = mfolder
         fileNumber = "44"


### PR DESCRIPTION
This branch has four separate bug fixes, one per commit. Each commit adds a test model under test/ and a regression test in validate/validate.py. Every commit builds and passes its own tests on its own, so they can be reviewed or taken one at a time.

All four were found while running NFsim inside another simulator. In each case the reference answer comes from BioNetGen. The model is expanded with generate_network() and simulated deterministically, which reaches the same answer by an independent route.

The four fixes are:

1. A rule whose reactant pattern is symmetric ran twice as fast as intended under every rate law except the constant one.
2. A rule that breaks several bonds at once to open a ring could never fire.
3. A Species observable reported counts far above what the model physically contained when no bookkeeping flag was given.
4. A rule whose catalyst is a repeated structure ran too fast, by the number of matching molecules in that catalyst. This one fixes issue #87.

## 1. The symmetry factor is discarded for most rate laws

The ReactionClass constructor multiplies its own baseRate argument by the symmetry factor. The member variable of the same name was copied out of that argument a few lines earlier, so the multiplication updates a local copy that is then thrown away.

Only the constant rate law recovers the factor, because NFinput calls setBaseRate() after the constructor and that function applies the factor itself. Every other rate law is built with baseRate set to 1 and never calls setBaseRate. A rule whose reactant pattern has a symmetry therefore fires at twice its intended rate under a global function, a local function, a function product, or a Michaelis-Menten rate law.

BioNetGen settles which side is wrong. RxnRule.pm computes this factor and writes it into the model file for every rule regardless of rate law. BioNetGen 2.9.3 writes a symmetry factor of 0.5 for a symmetric rule under a function rate law, a Michaelis-Menten rate law, and a constant rate law alike. The four affected rate laws disagree with BioNetGen, and they also disagree with NFsim's own constant rate path for the very same rule.

The fix assigns through this-> so the member actually receives the correction.

Five pools of 4000 dimers decay under five rate laws that all encode the same intended rate per dimer, so a single expected value covers all of them. Averaged over five seeds at time 1000, the correct answer is 1471.5 and a discarded factor gives 541.3.

| pool | rate law | before | after |
|---|---|---|---|
| Sym_fn | global function | 541.8 | 1469.4 |
| Sym_dor | local function | 545.8 | 1474.2 |
| Sym_mm | Michaelis-Menten | 528.8 | 1460.4 |
| Sym_k | constant, control | 1478.8 | 1480.2 |
| Asym_fn | asymmetric global function, control | 1458.2 | 1467.4 |
| Asym_mm | asymmetric Michaelis-Menten, control | 1465.4 | 1467.4 |

For the Michaelis-Menten rate law the factor is applied to the substrate count inside the rate law. What the factor corrects is how many times a pattern matches. A symmetric substrate pattern matches each complex twice, so the rate law is handed more substrate than actually exists. The Michaelis-Menten expression is not linear in that count, so applying the factor to the finished reaction rate instead agrees only while the enzyme is far from saturated.

A second test model separates the two choices, with the substrate held at 0.4 times Km. Its two rules differ only in whether the two halves of the substrate dimer are the same molecule type, so they have to decay together. Averaged over ten seeds at time 2000, the symmetric pool and its control end at 164.4 and 761.2 with no factor at all, at 993.9 and 751.8 with the factor on the finished rate, and at 758.0 and 756.3 with the factor on the substrate count.

This commit merges with pull request #88, which rewrote MMRxnClass::update_a for numerical precision. That rewritten expression is left exactly as it was.

## 2. A rule that breaks several bonds at once can never fire

The check added for issue #48 and narrowed by issue #61 makes sure a dissociation rule fires only when breaking the bond really does separate the complex into two pieces. The helper it calls, canReachExcludingBond, removes a single bond and asks whether the two partners are still connected by some other route.

That is the wrong question for a rule that opens a ring by breaking several bonds together. Each bond on its own leaves the partners connected through the others, so the check rejects all of them and the rule never fires at all. The smallest example is two molecules held together by two bonds, with a rule that breaks both. Those two molecules can never come apart, and the model stays stuck in that state.

The fix collects every bond the rule will break and removes all of them before asking whether the partners are still connected. Breaking a single bond inside a larger ring still leaves the partners connected, so those rules stay blocked. This refines the behaviour that issues #48 and #61 produced instead of undoing it.

On a model seeded with 197 of those two bond pairs, averaged over three seeds at time 200000, the number of free single molecules stayed at 0 before the fix and reaches 64.0 after it. Simulating BioNetGen's generated network deterministically gives about 63. The conserved molecule total is 394 in both cases.

The opposite case has to stay rejected, and it does. On a model where the rule breaks one bond inside a larger ring, the count of intact rings stays at exactly 100 with no variation across seeds, both before and after.

Renaming canReachExcludingBond to canReachExcludingBonds changes a function that the unit test in src/NFtest/transformations calls, so that test moves to the new signature. It also gains a case the old signature had no way to express, where two molecules are bound to each other twice.

## 3. Species observables need complex tracking on their own account

System.useComplex controls whether NFsim keeps track of which molecules belong to which complex. It was set only from the blockSameComplexBinding argument. A Species observable is counted by walking over complexes, so it needs that tracking, and it needs it from the moment the System is built. The retroactive setUsingComplex() call added for issue #49 happens too late to repair counters that have already been updated wrongly.

The fix scans the model file for a Species observable before the System is built, and turns complex tracking on if it finds one.

On the same model of 197 two bond pairs, run with no flags, the Species observable reported 3612.3 before the fix, for a model that never contained more than 197 of them. After the fix it reports 165.0, which agrees with the same run under the bookkeeping flag. The plain molecule count was correct at 394 throughout.

It is worth being clear about how much this changes. NFsim.cpp already computes a combined flag from turnOnComplexBookkeeping and blockSameComplexBinding and passes that as this argument. Anyone running the command line program with either flag already had complex tracking and will see no difference. What changes is the run with neither flag, and any program that calls NFinput::initializeFromXML directly. That second case is how this was found. A model whose observables cannot be counted correctly without complex tracking now gets it because of what the model declares, instead of depending on the user remembering a flag.

Two open issues sit close to this one.

Issue #51 covers the reactant side of the same theme. It is deliberately left alone here. That behaviour is controlled by a separate call, ts->setComplexBookkeeping(blockSameComplexBinding), and widening it would change which reactions are allowed rather than correcting a count.

Issue #86 is not fixed by this change. That seems better said plainly than left to be assumed. The report was run with the complex bookkeeping flag, so tracking was already on and this commit makes no difference to it. I also built the closest case I could, a rule that changes a molecule's state at a rate read from a Species observable, with a rate read from a Molecules observable as a control. The rate followed its observable correctly both before and after this change. Whatever causes issue #86 therefore looks specific to its rules that create molecules from nothing, and it stays open.

## 4. A catalyst the rule does not change is counted once per molecule

This fixes issue #87.

When a rule does not change one of its reactant patterns, BioNetGen counts one reaction for each matching complex, however many molecules inside that complex match. All of those matches produce the same reaction, so there is only one reaction to count. NFsim counts one for each matching molecule. A catalyst built from two identical subunits therefore drove its rule twice as fast as a catalyst built from two different ones, and a three membered ring three times as fast.

Two things here are easy to get wrong, and the test model covers both.

The first is that symmetry is not the cause. One pool uses a single molecule pattern against a complex holding two copies at positions that are plainly different from each other. Nothing about it is symmetric, and it was still counted twice. Dividing the number of matches by the number of symmetries of the pattern, which is what issue #87 suggests, gives the wrong answer for that pool. The sharpest case is a single molecule pattern against a three membered ring. Dividing by symmetries gives 3, halving gives 1.5, counting once per complex gives 1, and BioNetGen gives 1.

The second is that the EMPTY transformation type does not mean the rule leaves a pattern alone. finalize() attaches an EMPTY transformation to every reactant the rule does not change. genBindingTransform2() also attaches EMPTY to the second partner of a binding, and that partner really is part of the reaction. BioNetGen deliberately gives such a rule twice the rate constant. Working out afterwards which reactants are untouched, by looking at transformation types, would misclassify exactly that rule and remove a factor that belongs there. finalize() now records which reactants are untouched before it attaches the placeholder.

Averaged over ten seeds at time 2000. Every pool carries the same intended rate per substrate, so the expected answer is 2426.1 from BioNetGen's network simulated deterministically, and 2344.8 for the Michaelis-Menten pair. Each pool has a control alongside it with a single subunit catalyst at the same complex count and rate constant.

| pool | catalyst | before | after | control |
|---|---|---|---|---|
| Dim_sym | two identical subunits, constant rate | 1485.1 | 2443.6 | 2418.9 |
| Fn_sym | two identical subunits, global function | 1485.4 | 2440.0 | 2416.7 |
| Dor_sym | two identical subunits, local function | 1480.8 | 2442.7 | 2434.6 |
| Mm_sym | symmetric enzyme, Michaelis-Menten | 1319.0 | 2345.7 | 2342.0 |
| Ring_sym | three membered ring | 899.1 | 2436.9 | 2411.6 |
| Sub_subunit | one subunit of a two subunit catalyst | 1474.2 | 2424.1 | |
| Sub_scaffold | two copies at clearly different positions | 1472.6 | 2426.7 | |
| Sub_trimer | one subunit of a three membered ring | 886.5 | 2417.7 | |

The correction must not reach a pattern the rule does change. Two further pools guard that direction and neither moves. Bind_sym, whose catalyst is bound by the rule and which BioNetGen gives twice the rate constant, goes from 218.4 to 218.1. Its control Bind_asym goes from 320.1 to 321.9.

This needs complex tracking. Without it every molecule reports the same placeholder complex identifier, so there is no way to tell two molecules in one complex from two separate complexes, and the counting is skipped.

The performance work is part of this commit instead of a later one. Counting complexes on every rate update takes time proportional to the number of matches, which made a transcription model 43 times slower. ReactantList and ReactantTree now record whether any molecule they hold has ever belonged to a complex of more than one molecule. While that stays false, one match is one complex, the count is simply the list size, and the scan is skipped. The record errs on the safe side, because a stale true value only costs the scan.

The exact RuleMonkey code paths get the same correction. Where they enumerate pairs of reactants, they now take one representative per complex for an untouched reactant, so the pairs they subtract are counted on the same basis as the totals they are subtracted from.

A before and after comparison over 181 models from the RuleMonkey corpora at a fixed seed gave 169 models identical and actually progressing, 2 that did nothing, 10 that failed the same way in both runs, and a single model that changed. That one was the deliberate positive control.

## Testing

Every commit was built and tested on its own.

validate/validate.py gains seven tests. Against unmodified master, the five that assert corrected behaviour all fail, each with a message naming the problem. The two that guard behaviour which must not change both pass. Those two are test_singlebond_ring_dissociation_stays_blocked and test_a_transformed_symmetric_pattern_keeps_both_of_its_sites.

The rest of the suite is unaffected. Master and this branch produce the same four failures and one error. All five come from the bionetgen Python package being uninstallable in the environment used here, which those tests need in order to generate their model files.

NFsim -test transformations passes at every commit.
